### PR TITLE
fix: SCL inherits from Task, not from LightningTask

### DIFF
--- a/docs/tutorials/tasks.md
+++ b/docs/tutorials/tasks.md
@@ -31,7 +31,7 @@ graph LR;
     T-->E(Evaluation);
     L-->SG(Segmentation);
     L-->CL(Classification);
-    L-->SCL(SklearnClassification);
+    T-->SCL(SklearnClassification);
     L-->SSL(SSL);
     L-->AD(AnomalibDetection)
 ```


### PR DESCRIPTION
## Summary

Small fix in docs/tutorials/tasks.md . The SklearnClassification Task has Task as Parent class.

## Type of Change

Please select the one relevant option below:

- Documentation fix


Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

