### PR TITLE
Bug: non squared input images break SklearnClassification task

### DIFF
--- a/quadra/utils/vit_explainability.py
+++ b/quadra/utils/vit_explainability.py
@@ -12,7 +12,7 @@ from sklearn.linear_model._base import LinearClassifierMixin
 
 
 def rollout(
-    attentions: List[torch.Tensor], discard_ratio: float = 0.9, head_fusion: str = "mean", aspect_ratio: float = 1
+    attentions: List[torch.Tensor], discard_ratio: float = 0.9, head_fusion: str = "mean", aspect_ratio: float = 1.0
 ) -> np.ndarray:
     """Apply rollout on Attention matrices.
 
@@ -134,7 +134,7 @@ class VitAttentionRollout:
 
 
 def grad_rollout(
-    attentions: List[torch.Tensor], gradients: List[torch.Tensor], discard_ratio: float = 0.9, aspect_ratio: float = 1
+    attentions: List[torch.Tensor], gradients: List[torch.Tensor], discard_ratio: float = 0.9, aspect_ratio: float = 1.0
 ) -> np.ndarray:
     """Apply gradient rollout on Attention matrices.
 

--- a/quadra/utils/vit_explainability.py
+++ b/quadra/utils/vit_explainability.py
@@ -10,10 +10,6 @@ import numpy as np
 import torch
 from sklearn.linear_model._base import LinearClassifierMixin
 
-from quadra.utils.utils import get_logger
-
-log = get_logger(__name__)
-
 
 def rollout(
     attentions: List[torch.Tensor], discard_ratio: float = 0.9, head_fusion: str = "mean", aspect_ratio: float = 1


### PR DESCRIPTION
## Summary

Describe the purpose of the pull request, including:

- What problem does it solve?
Non squared input images currently brake sklearn classification task in two ways:
1- torchscript export fails
2- gradcam fails
- How does it solve the problem?
1-?
2- Now mask is reconstructed correctly even when width and height are different.
- Remaining issues
1- I have not tried to solve this problem yet.
2- The mask adjustment is not a trivial task. The reshape() function needs integers, so you need to find two values, height and width, such that w*h = total_size of the mask. But there is no way to know a priori how to truncate height and width values. The solution that satisfied me the most (based on output gradcams) implies a reduction of mask values. I did different tests and the resulting gradcams seem good.

## Type of Change

Please select the one relevant option below:

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

## Screenshots or Visuals (Optional)

If applicable, please provide screenshots, diagrams, graphs, or videos of the changes, features or the error.

