### PR TITLE
Feat/ Propagate input size classificazione

### DIFF
--- a/quadra/tasks/anomaly.py
+++ b/quadra/tasks/anomaly.py
@@ -337,19 +337,19 @@ class AnomalibEvaluation(Task[AnomalyDataModule]):
         if not isinstance(self.model_data, dict):
             raise ValueError("Model info file is not a valid json")
 
-        if self.model_data["input_size"][0] != self.config.transforms.input_height:
+        if self.model_data["input_size"][0] != self.config.transforms.input_width:
             log.warning(
-                f"Input height of the model ({self.model_data['input_size'][0]}) is different from the one specified "
-                + f"in the config ({self.config.transforms.input_height}). Fixing the config."
-            )
-            self.config.transforms.input_height = self.model_data["input_size"][0]
-
-        if self.model_data["input_size"][1] != self.config.transforms.input_width:
-            log.warning(
-                f"Input width of the model ({self.model_data['input_size'][1]}) is different from the one specified "
+                f"Input width of the model ({self.model_data['input_size'][0]}) is different from the one specified "
                 + f"in the config ({self.config.transforms.input_width}). Fixing the config."
             )
-            self.config.transforms.input_width = self.model_data["input_size"][1]
+            self.config.transforms.input_width = self.model_data["input_size"][0]
+
+        if self.model_data["input_size"][1] != self.config.transforms.input_height:
+            log.warning(
+                f"Input height of the model ({self.model_data['input_size'][1]}) is different from the one specified "
+                + f"in the config ({self.config.transforms.input_height}). Fixing the config."
+            )
+            self.config.transforms.input_height = self.model_data["input_size"][1]
 
         self.deployment_model = self.model_path
 

--- a/quadra/tasks/classification.py
+++ b/quadra/tasks/classification.py
@@ -987,19 +987,19 @@ class ClassificationEvaluation(Task[ClassificationDataModuleT]):
         if not isinstance(self.model_data, dict):
             raise ValueError("Model info file is not a valid json")
 
-        if self.model_data["input_size"][0] != self.config.transforms.input_height:
+        if self.model_data["input_size"][0] != self.config.transforms.input_width:
             log.warning(
-                f"Input height of the model ({self.model_data['input_size'][0]}) is different from the one specified "
-                + f"in the config ({self.config.transforms.input_height}). Fixing the config."
-            )
-            self.config.transforms.input_height = self.model_data["input_size"][0]
-
-        if self.model_data["input_size"][1] != self.config.transforms.input_width:
-            log.warning(
-                f"Input width of the model ({self.model_data['input_size'][1]}) is different from the one specified "
+                f"Input width of the model ({self.model_data['input_size'][0]}) is different from the one specified "
                 + f"in the config ({self.config.transforms.input_width}). Fixing the config."
             )
-            self.config.transforms.input_width = self.model_data["input_size"][1]
+            self.config.transforms.input_width = self.model_data["input_size"][0]
+
+        if self.model_data["input_size"][1] != self.config.transforms.input_height:
+            log.warning(
+                f"Input height of the model ({self.model_data['input_size'][1]}) is different from the one specified "
+                + f"in the config ({self.config.transforms.input_height}). Fixing the config."
+            )
+            self.config.transforms.input_height = self.model_data["input_size"][1]
 
         self.deployment_model = self.model_path
 


### PR DESCRIPTION
## Summary

Adding input_size propagation in Classification and Anomaly evaluation tasks.
We want to automatically change transforms.input_weight and transforms.input_height config parameters if tested model has non default input_size.

Update: these modifications have been integrated to Evaluation Task refactoring pr. Closing this pr.