### PR TITLE
Hotfix/tutorial_link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [1.1.1]
+
+#### Fixed
+
+- Fix deprecated link for tutorials in `README.md` file.
+
 ### [1.1.0]
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
   <a href="https://orobix.github.io/quadra/latest/index.html">Docs</a> •
-  <a href="https://orobix.github.io/quadra/latest/tutorials/install.html">Tutorials</a> •
+  <a href="https://orobix.github.io/quadra/latest/tutorials/datamodules.html">Tutorials</a> •
   <a href="https://orobix.github.io/quadra/latest/tutorials/configurations.html">Configurations</a>
 </p>
 


### PR DESCRIPTION
## Summary

This PR fixes the issue inside `README.md` file where the link for tutorials is broken due to the removed file. Now the tutorial link refers to the first item under the tutorial parent folder.

## Type of Change

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [ ] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

