### PR TITLE
Fix/segmentation wrong test checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [1.1.2]
+
+#### Fixed
+
+- Fix best checkpoint not used for testing when available in `LightningTask` class.
+
 ### [1.1.1]
 
 #### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quadra"
-version = "1.1.1"
+version = "1.1.2"
 description = "Deep Learning experiment orchestration library"
 authors = [
   {name = "Alessandro Polidori", email = "alessandro.polidori@orobix.com"},
@@ -117,7 +117,7 @@ repository = "https://github.com/orobix/quadra"
 
 # Adapted from https://realpython.com/pypi-publish-python-package/#version-your-package
 [tool.bumpver]
-current_version = "1.1.1"
+current_version = "1.1.2"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message  = "build: Bump version {old_version} -> {new_version}"
 commit          = true

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 
 def get_version():


### PR DESCRIPTION
## Summary

PR to solve #38 

I've changed the default behaviour in LightningTask to automatically use the best checkpoint model for testing if available or fallback to the last weights if no checkpoint was configured (with a warning).

## Type of Change

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [X] I have added unit tests for my changes, or updated existing tests if necessary.
- [X] I have updated the documentation, if applicable.
- [X] I have installed pre-commit and run locally for my code changes.
