### PR TITLE
Fix/wrong patch extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [1.1.3]
+
+#### Fixed
+
+- Fix penultimate patch extracted containing replicated data, now the penultimate patch contain the right data. Fix also the patch size and step computation to avoid generating more than one extra patch.
+
 ### [1.1.2]
 
 #### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quadra"
-version = "1.1.2"
+version = "1.1.3"
 description = "Deep Learning experiment orchestration library"
 authors = [
   {name = "Alessandro Polidori", email = "alessandro.polidori@orobix.com"},
@@ -117,7 +117,7 @@ repository = "https://github.com/orobix/quadra"
 
 # Adapted from https://realpython.com/pypi-publish-python-package/#version-your-package
 [tool.bumpver]
-current_version = "1.1.2"
+current_version = "1.1.3"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message  = "build: Bump version {old_version} -> {new_version}"
 commit          = true

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 
 def get_version():


### PR DESCRIPTION
## Summary

The refactored patch extraction still had some issues, particularly the penultimate patch was extracted improperly as a certain percentage of its content was taken from the last patch rather than the right position.
This was causing no issues with the standard priority reconstruction, but it didn't work when we try to sum predictions like in the case of major voting reconstruction.

This PR aims to fix this problem by refactoring a little the logic behind the computation of patch size and step and generating the extra patch in a later stage rather than trying to put everything togethter and then use view as windows.

## Type of Change

Please select the one relevant option below:

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [X] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [X] I have added unit tests for my changes, or updated existing tests if necessary.
- [ ] I have updated the documentation, if applicable.
- [X] I have installed pre-commit and run locally for my code changes.