### PR TITLE
Improve anomaly threshold usage in inference task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [1.2.6]
+
+#### Added
+
+- Add optional `training_threshold_type` for anomaly detection inference task.
+#### Changed
+
+- Compute results using the training image threshold instead of zero when running anomaly inference with no labelled data.
+
 ### [1.2.5]
 
 #### Fixed

--- a/docs/tutorials/examples/anomaly_detection.md
+++ b/docs/tutorials/examples/anomaly_detection.md
@@ -290,9 +290,11 @@ datamodule:
 task:
   model_path: ???
   use_training_threshold: false
+  training_threshold_type: image
 ```
 
 By default, the inference will recompute the threshold based on test data to maximize the F1-score, if you want to use the threshold from the training phase you can set the `use_training_threshold` parameter to true.
+The `training_threshold_type` can be used to specify which training threshold to use, it can be either `image` or `pixel`, if not specified the `image` threshold will be used.
 
 The model path is the path to an exported model, at the moment `torchscript` and `onnx` models are supported (exported automatically after a training experiment). Right now only the `CFLOW` model is not supported for inference as it's not compatible with botyh torchscript and onnx.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quadra"
-version = "1.2.5"
+version = "1.2.6"
 description = "Deep Learning experiment orchestration library"
 authors = [
   { name = "Alessandro Polidori", email = "alessandro.polidori@orobix.com" },
@@ -118,7 +118,7 @@ repository = "https://github.com/orobix/quadra"
 
 # Adapted from https://realpython.com/pypi-publish-python-package/#version-your-package
 [tool.bumpver]
-current_version = "1.2.5"
+current_version = "1.2.6"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "build: Bump version {old_version} -> {new_version}"
 commit = true

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 
 
 def get_version():

--- a/quadra/configs/experiment/base/anomaly/inference.yaml
+++ b/quadra/configs/experiment/base/anomaly/inference.yaml
@@ -18,3 +18,4 @@ datamodule:
 task:
   model_path: ???
   use_training_threshold: false
+  training_threshold_type: image

--- a/quadra/tasks/anomaly.py
+++ b/quadra/tasks/anomaly.py
@@ -362,9 +362,9 @@ class AnomalibEvaluation(Evaluation[AnomalyDataModule]):
                 optimal_f1_score = optimal_f1.compute()
                 threshold = optimal_f1.threshold
         else:
-            log.warning("No ground truth available during evaluation, F1 score and threshold set to 0")
+            log.warning("No ground truth available during evaluation, use training threshold for reporting")
             optimal_f1_score = torch.tensor(0)
-            threshold = torch.tensor(0)
+            threshold = torch.tensor(float(self.model_data["image_threshold"]))
 
         log.info("Computed F1 score: %s", optimal_f1_score.item())
         self.metadata["anomaly_scores"] = anomaly_scores

--- a/quadra/tasks/anomaly.py
+++ b/quadra/tasks/anomaly.py
@@ -2,7 +2,7 @@ import glob
 import json
 import os
 from collections import Counter
-from typing import Dict, Generic, List, Optional, TypeVar, Union, cast
+from typing import Dict, Generic, List, Literal, Optional, TypeVar, Union, cast
 
 import cv2
 import hydra
@@ -297,11 +297,25 @@ class AnomalibEvaluation(Evaluation[AnomalyDataModule]):
     """
 
     def __init__(
-        self, config: DictConfig, model_path: str, use_training_threshold: bool = False, device: Optional[str] = None
+        self,
+        config: DictConfig,
+        model_path: str,
+        use_training_threshold: bool = False,
+        device: Optional[str] = None,
+        training_threshold_type: Optional[Literal["image", "pixel"]] = None,
     ):
         super().__init__(config=config, model_path=model_path, device=device)
 
         self.use_training_threshold = use_training_threshold
+
+        if training_threshold_type is not None and training_threshold_type not in ["image", "pixel"]:
+            raise ValueError("Training threshold type must be either image or pixel")
+
+        if training_threshold_type is None and use_training_threshold:
+            log.warning("Using training threshold but no training threshold type is provided, defaulting to image")
+            training_threshold_type = "image"
+
+        self.training_threshold_type = training_threshold_type
 
     def prepare(self) -> None:
         """Prepare the evaluation."""
@@ -349,7 +363,7 @@ class AnomalibEvaluation(Evaluation[AnomalyDataModule]):
         if any(x != -1 for x in image_labels):
             if self.use_training_threshold:
                 _image_labels = torch.tensor(image_labels)
-                threshold = torch.tensor(float(self.model_data["image_threshold"]))
+                threshold = torch.tensor(float(self.model_data[f"{self.training_threshold_type}_threshold"]))
                 known_labels = torch.where(_image_labels != -1)[0]
 
                 _image_labels = _image_labels[known_labels]
@@ -362,7 +376,7 @@ class AnomalibEvaluation(Evaluation[AnomalyDataModule]):
                 optimal_f1_score = optimal_f1.compute()
                 threshold = optimal_f1.threshold
         else:
-            log.warning("No ground truth available during evaluation, use training threshold for reporting")
+            log.warning("No ground truth available during evaluation, use training image threshold for reporting")
             optimal_f1_score = torch.tensor(0)
             threshold = torch.tensor(float(self.model_data["image_threshold"]))
 


### PR DESCRIPTION
## Summary

This PR aims to solve two problems:

- It was not possible to specify the type of the training threshold when running an anomaly inference task, by default always the image one was used.
- If no labels were provided for inference by default report was generated using 0 as a threshold leading to poor results, now the image level training threshold is used

As it is a non breaking feature we still keep it as 1.2.x

## Type of Change

- New feature (non-breaking change that adds functionality)

## Checklist

Please confirm that the following tasks have been completed:

- [X] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [X] I have added unit tests for my changes, or updated existing tests if necessary.
- [X] I have updated the documentation, if applicable.
- [X] I have installed pre-commit and run locally for my code changes.
