### PR TITLE
Automatic batch size and safe testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quadra"
-version = "1.2.6"
+version = "1.3.0"
 description = "Deep Learning experiment orchestration library"
 authors = [
   { name = "Alessandro Polidori", email = "alessandro.polidori@orobix.com" },
@@ -118,7 +118,7 @@ repository = "https://github.com/orobix/quadra"
 
 # Adapted from https://realpython.com/pypi-publish-python-package/#version-your-package
 [tool.bumpver]
-current_version = "1.2.6"
+current_version = "1.3.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "build: Bump version {old_version} -> {new_version}"
 commit = true

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.6"
+__version__ = "1.3.0"
 
 
 def get_version():

--- a/quadra/configs/callbacks/default.yaml
+++ b/quadra/configs/callbacks/default.yaml
@@ -20,5 +20,14 @@ progress_bar:
 lightning_trainer_setup:
   _target_: quadra.callbacks.lightning.LightningTrainerBaseSetup
   log_every_n_steps: 1
+
+batch_size_finder:
+  _target_: pytorch_lightning.callbacks.BatchSizeFinder
+  mode: power
+  steps_per_trial: 3
+  init_val: 2
+  max_trials: 5 # Max 64
+  batch_arg_name: batch_size
+  disable: true
 #gpu_stats: TODO: This is not working with the current PL version
 #  _target_: nvitop.callbacks.lightning.GpuStatsLogger

--- a/quadra/configs/task/sklearn_classification.yaml
+++ b/quadra/configs/task/sklearn_classification.yaml
@@ -1,7 +1,10 @@
 _target_: quadra.tasks.SklearnClassification
-device: "cuda:0"
+device: cuda:0
+automatic_batch_size:
+  starting_batch_size: 1024
+  disable: true
 output:
-  folder: "classification_experiment"
+  folder: classification_experiment
   report: true
   example: true
   test_full_data: true

--- a/quadra/configs/task/sklearn_classification_patch.yaml
+++ b/quadra/configs/task/sklearn_classification_patch.yaml
@@ -1,5 +1,8 @@
 _target_: quadra.tasks.PatchSklearnClassification
-device: cuda:2
+device: cuda:0
+automatic_batch_size:
+  starting_batch_size: 1024
+  disable: true
 output:
   folder: classification_patch_experiment
   report: true

--- a/quadra/tasks/anomaly.py
+++ b/quadra/tasks/anomaly.py
@@ -24,6 +24,7 @@ from quadra.modules.base import ModelSignatureWrapper
 from quadra.tasks.base import Evaluation, LightningTask
 from quadra.utils import utils
 from quadra.utils.classification import get_results
+from quadra.utils.evaluation import automatic_datamodule_batch_size
 from quadra.utils.export import export_model
 
 log = utils.get_logger(__name__)
@@ -307,13 +308,14 @@ class AnomalibEvaluation(Evaluation[AnomalyDataModule]):
         """Prepare the evaluation."""
         super().prepare()
         self.datamodule = self.config.datamodule
-
-    def test(self) -> None:
-        """Perform test."""
-        log.info("Running test")
         # prepare_data() must be explicitly called because there is no lightning training
         self.datamodule.prepare_data()
         self.datamodule.setup(stage="test")
+
+    @automatic_datamodule_batch_size(batch_size_attribute_name="test_batch_size")
+    def test(self) -> None:
+        """Perform test."""
+        log.info("Running test")
         test_dataloader = self.datamodule.test_dataloader()
 
         optimal_f1 = OptimalF1(num_classes=None, pos_label=1)  # type: ignore[arg-type]

--- a/quadra/tasks/base.py
+++ b/quadra/tasks/base.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 import hydra
 import torch
 from hydra.core.hydra_config import HydraConfig
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig, OmegaConf, open_dict
 from pytorch_lightning import Callback, LightningModule, Trainer
 from pytorch_lightning.loggers import Logger, MLFlowLogger
 from pytorch_lightning.utilities.device_parser import parse_gpu_ids
@@ -173,6 +173,15 @@ class LightningTask(Generic[DataModuleT], Task[DataModuleT]):
         instatiated_callbacks = []
         for _, cb_conf in callbacks_config.items():
             if "_target_" in cb_conf:
+                # Disable is a reserved keyword for callbacks, hopefully no callback will use it
+                if "disable" in cb_conf:
+                    if cb_conf["disable"]:
+                        log.info("Skipping callback <%s> as it is disabled", cb_conf["_target_"])
+                        continue
+
+                    with open_dict(cb_conf):
+                        del cb_conf.disable
+
                 if not torch.cuda.is_available():
                     # Skip the gpu stats logger callback if no gpu is available to avoid errors
                     if cb_conf["_target_"] == "nvitop.callbacks.lightning.GpuStatsLogger":

--- a/quadra/tasks/patch.py
+++ b/quadra/tasks/patch.py
@@ -17,6 +17,7 @@ from quadra.tasks.base import Evaluation, Task
 from quadra.trainers.classification import SklearnClassificationTrainer
 from quadra.utils import utils
 from quadra.utils.classification import automatic_batch_size_computation
+from quadra.utils.evaluation import automatic_datamodule_batch_size
 from quadra.utils.export import export_model, import_deployment_model
 from quadra.utils.patch import RleEncoder, compute_patch_metrics, save_classification_result
 from quadra.utils.patch.dataset import PatchDatasetFileFormat
@@ -315,11 +316,13 @@ class PatchSklearnTestClassification(Evaluation[PatchSklearnClassificationDataMo
         # Configure trainer
         self.trainer = self.config.trainer
 
-    def test(self) -> None:
-        """Run the test."""
         # prepare_data() must be explicitly called because there is no lightning training
         self.datamodule.prepare_data()
         self.datamodule.setup(stage="test")
+
+    @automatic_datamodule_batch_size(batch_size_attribute_name="batch_size")
+    def test(self) -> None:
+        """Run the test."""
         test_dataloader = self.datamodule.test_dataloader()
 
         self.class_to_skip = self.model_data["class_to_skip"] if hasattr(self.model_data, "class_to_skip") else None

--- a/quadra/utils/evaluation.py
+++ b/quadra/utils/evaluation.py
@@ -1,5 +1,6 @@
 import os
 from ast import literal_eval
+from functools import wraps
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
@@ -14,7 +15,17 @@ from segmentation_models_pytorch.losses import DiceLoss
 from segmentation_models_pytorch.losses.constants import BINARY_MODE, MULTICLASS_MODE
 from skimage.measure import label, regionprops
 
+from quadra.utils.logger import get_logger
 from quadra.utils.visualization import UnNormalize, create_grid_figure
+
+try:
+    from onnxruntime.capi.onnxruntime_pybind11_state import RuntimeException  # noqa
+
+    ONNX_AVAILABLE = True
+except ImportError:
+    ONNX_AVAILABLE = False
+
+log = get_logger(__name__)
 
 
 def dice(
@@ -313,7 +324,6 @@ def create_mask_report(
         )
 
         if len(fg["image"]) > 0:
-
             if len(fg["image"]) > nb_samples:
                 for k, v in fg.items():
                     fg[k] = v[:nb_samples]
@@ -363,3 +373,50 @@ def create_mask_report(
         file_paths.append(analysis_file_path)
 
     return file_paths
+
+
+def automatic_datamodule_batch_size(batch_size_attribute_name: str = "batch_size"):
+    """Automatically scale the datamodule batch size if the given function goes out of memory.
+
+    Args:
+        batch_size_attribute_name: The name of the attribute to modify in the datamodule
+    """
+
+    def decorator(func: Callable):
+        """Decorator function."""
+
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            """Wrapper function."""
+            is_func_finished = False
+            while not is_func_finished:
+                valid_exceptions = (RuntimeError,)
+
+                if ONNX_AVAILABLE:
+                    valid_exceptions += (RuntimeException,)
+
+                try:
+                    func(self, *args, **kwargs)
+                except valid_exceptions as e:
+                    if "out of memory" in str(e) or "Failed to allocate memory" in str(e):
+                        current_batch_size = getattr(self.datamodule, batch_size_attribute_name)
+                        setattr(self.datamodule, batch_size_attribute_name, current_batch_size // 2)
+                        log.warning(
+                            "The function %s went out of memory, trying to reduce the batch size to %d",
+                            func.__name__,
+                            self.datamodule.batch_size,
+                        )
+
+                        if self.datamodule.batch_size == 0:
+                            raise RuntimeError(
+                                f"Unable to run {func.__name__} with batch size 1, the program will exit"
+                            ) from e
+                        continue
+
+                    raise e
+
+                is_func_finished = True
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## Summary

This PR integrates two changes:

- Added flags to automatically infer maximum training batch size for lightning based tasks and sklearn based tasks
- Added decorator wrapping evaluation tasks test function to repeat the test with a smaller batch size in case of out of memory issues

## Type of Change

- New feature (non-breaking change that adds functionality)

## Checklist

Please confirm that the following tasks have been completed:

- [] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [X] I have added unit tests for my changes, or updated existing tests if necessary.
- [ ] I have updated the documentation, if applicable.
- [X] I have installed pre-commit and run locally for my code changes.
