### PR TITLE
Upgrade pandas requirement version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [1.3.1]
+
+#### Updated
+
+- Update pandas requirements to use a more recent version and avoid slow build time when python 3.10 is used.
+
 ### [1.3.0]
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "tensorboard==2.11.*",
   # --------- others --------- #
   "Pillow==9.3.0",                                                        # required by label-studio-converter
-  "pandas==1.1.*",
+  "pandas<2.0.0",
   "opencv-python-headless==4.7.0.*",
   "python-dotenv==0.21.*",
   "rich==13.2.*",
@@ -64,7 +64,7 @@ dependencies = [
   "h5py==3.8.*",
   "timm==0.6.12", # required by smp
   "segmentation-models-pytorch==0.3.2",
-  "anomalib@git+https://github.com/orobix/anomalib.git@v0.7.0+obx.1.2.3",
+  "anomalib@git+https://github.com/orobix/anomalib.git@v0.7.0+obx.1.2.4",
   "xxhash==3.2.*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quadra"
-version = "1.3.0"
+version = "1.3.1"
 description = "Deep Learning experiment orchestration library"
 authors = [
   { name = "Alessandro Polidori", email = "alessandro.polidori@orobix.com" },
@@ -119,7 +119,7 @@ repository = "https://github.com/orobix/quadra"
 
 # Adapted from https://realpython.com/pypi-publish-python-package/#version-your-package
 [tool.bumpver]
-current_version = "1.3.0"
+current_version = "1.3.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "build: Bump version {old_version} -> {new_version}"
 commit = true

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 
 def get_version():


### PR DESCRIPTION
## Summary

The current pandas version is so old that Python 3.10 pre-compiled wheel is not available causing slowdowns in package installation, this pr aims to solve this issue. Anomalib version is also updated as it was requiring the same old pandas version.

closes #74 

## Type of Change

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [X] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [X] I have added unit tests for my changes, or updated existing tests if necessary.
- [X] I have updated the documentation, if applicable.
- [X] I have installed pre-commit and run locally for my code changes.
