### PR TITLE
fix: mlflow versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [1.3.2]
+
+#### Updated
+
+- Update `mlflow` requirements for `mlflow-skinny` package to align with the same version of main `mlflow` package.
+
 ### [1.3.1]
 
 #### Updated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quadra"
-version = "1.3.1"
+version = "1.3.2"
 description = "Deep Learning experiment orchestration library"
 authors = [
   { name = "Alessandro Polidori", email = "alessandro.polidori@orobix.com" },
@@ -121,7 +121,7 @@ repository = "https://github.com/orobix/quadra"
 
 # Adapted from https://realpython.com/pypi-publish-python-package/#version-your-package
 [tool.bumpver]
-current_version = "1.3.1"
+current_version = "1.3.2"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "build: Bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,13 @@ dependencies = [
   "hydra-optuna-sweeper==1.2.*",
   # --------- loggers --------- #
   "mlflow==2.3.1",
+  "mlflow-skinny==2.3.1",
   "boto3==1.26.*", # needed for artifact storage
   "minio==7.1.*", # needed for artifact storage
   "tensorboard==2.11.*",
   # --------- others --------- #
-  "Pillow==9.3.0",                                                        # required by label-studio-converter
+  # required by label-studio-converter
+  "Pillow==9.3.0",                                                        
   "pandas<2.0.0",
   "opencv-python-headless==4.7.0.*",
   "python-dotenv==0.21.*",

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 
 def get_version():


### PR DESCRIPTION
## Summary

This PR fixes Mlflow versioning including `skinny` package. Previously, later versions of  `mlflow-skinny` could be installed even if we fix `mlflow` package version. In the future releases, we can drop the dependency of mlflow and add only `mlflow-skinny`.

## Type of Change

- Bug fix (non-breaking change that solves an issue)

## Checklist

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [ ] I have added unit tests for my changes, or updated existing tests if necessary.
- [ ] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

