### PR TITLE
Set cublas single buffer when determinism is requested

### DIFF
--- a/quadra/main.py
+++ b/quadra/main.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import hydra
@@ -35,6 +36,9 @@ def main(config: DictConfig):
     # Set seed for random number generators in pytorch, numpy and python.random
     seed_everything(config.core.seed, workers=True)
     setup_opencv()
+    if config.get("trainer").get("deterministic"):
+        log.info("Set CUBLAS single size buffer to enable determinism")
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:2"
 
     # Run specified task using the configuration composition
     task: Task = hydra.utils.instantiate(config.task, config, _recursive_=False)


### PR DESCRIPTION
## Summary

Describe the purpose of the pull request, including:

When trainer.deterministic is set to True, to avoid RuntimeError on some hardare configurations you must set a single buffer on the gpu via this cuBLAS env variable.

## Type of Change

Please select the one relevant option below:

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

