### PR TITLE
fix: Anomalib version is 1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 #### Updated
 
-- Update anomalib to [v0.7.0+obx.1.2.7] (added default padim n_features for resnets' old weights)
+- Update anomalib to [v0.7.0+obx.1.2.9] (added default padim n_features for resnets' old weights)
 
 ### [1.4.0]
 


### PR DESCRIPTION
## Summary

Please select the one relevant option below:

Super quick hotfix. Changelog anomalib version
