### PR TITLE
Feat/onnx models mlflow upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [1.5.7]
+
+#### Added
+
+- Add upload_models to core config
+
+#### Refactored
+
+- infer_signature_torch_model refactored to infer_signature_model
+
 ### [1.5.6]
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quadra"
-version = "1.5.6"
+version = "1.5.7"
 description = "Deep Learning experiment orchestration library"
 authors = [
   "Federico Belotti <federico.belotti@orobix.com>",

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.6"
+__version__ = "1.5.7"
 
 
 def get_version():

--- a/quadra/configs/core/default.yaml
+++ b/quadra/configs/core/default.yaml
@@ -7,4 +7,5 @@ cv2_num_threads: 1
 command: "python "
 experiment_path: null
 upload_artifacts: False
+upload_models: [torchscript] # Default behavior in quadra <= 1.5.6
 log_level: info

--- a/quadra/configs/core/default.yaml
+++ b/quadra/configs/core/default.yaml
@@ -7,5 +7,5 @@ cv2_num_threads: 1
 command: "python "
 experiment_path: null
 upload_artifacts: False
-upload_models: [torchscript] # Default behavior in quadra <= 1.5.6
+upload_models: ${export.types} # Default behavior in quadra <= 1.5.6
 log_level: info

--- a/quadra/datamodules/base.py
+++ b/quadra/datamodules/base.py
@@ -305,13 +305,18 @@ class BaseDataModule(LightningDataModule, metaclass=DecorateParentMethod):
             self.data.to_csv(self.dataset_file, index=False)
             log.info("Datamodule checkpoint saved to disk.")
 
-        if "targets" in self.data and not isinstance(self.data["targets"].iloc[0], np.ndarray):
-            # If we find a numpy array target it's very likely one hot encoded, in that case we don't want to print
+        if "targets" in self.data:
+            if isinstance(self.data["targets"].iloc[0], np.ndarray):
+                # If we find a numpy array target it's very likely one hot encoded,
+                # in that case we just print the number of train/val/test samples
+                grouping = ["split"]
+            else:
+                grouping = ["split", "targets"]
             log.info("Dataset Info:")
             split_order = {"train": 0, "val": 1, "test": 2}
             log.info(
                 "\n%s",
-                self.data.groupby(["split", "targets"])
+                self.data.groupby(grouping)
                 .size()
                 .to_frame()
                 .reset_index()

--- a/quadra/models/evaluation.py
+++ b/quadra/models/evaluation.py
@@ -306,6 +306,7 @@ class ONNXEvaluationModel(BaseEvaluationModel):
 
     def eval(self):
         """Fake interface to match torch models."""
+        return self
 
     def half(self):
         """Convert model to half precision."""

--- a/quadra/utils/visualization.py
+++ b/quadra/utils/visualization.py
@@ -69,6 +69,8 @@ def create_grid_figure(
         fig_size (Tuple[int, int], optional): Figure size. Defaults to (12, 8).
         bounds (Optional[List[Tuple[float, float]]], optional): Bounds for the images. Defaults to None.
     """
+    default_plt_backend = plt.get_backend()
+    plt.switch_backend("Agg")
     _, ax = plt.subplots(nrows=nrows, ncols=ncols, figsize=fig_size, squeeze=False)
     for i, row in enumerate(images):
         for j, image in enumerate(row):
@@ -84,6 +86,7 @@ def create_grid_figure(
     plt.tight_layout()
     plt.savefig(file_path, bbox_inches="tight", dpi=300, facecolor="white", transparent=False)
     plt.close()
+    plt.switch_backend(default_plt_backend)
 
 
 def create_visualization_dataset(dataset: torch.utils.data.Dataset):

--- a/tests/utilities/test_mlflow_export.py
+++ b/tests/utilities/test_mlflow_export.py
@@ -18,7 +18,7 @@ from pytest import raises
 
 from quadra.models.base import ModelSignatureWrapper
 from quadra.utils.export import generate_torch_inputs
-from quadra.utils.mlflow import infer_signature_model
+from quadra.utils.mlflow import infer_signature_input, infer_signature_model
 from quadra.utils.tests.models import DoubleInputModel, SingleInputModel
 
 
@@ -126,9 +126,9 @@ def test_nested_tuple_signature():
 
     # Nested structures are not supported
     with raises(ValueError):
-        infer_signature_input_torch(inputs)
+        infer_signature_input(inputs)
 
-    signature = infer_signature(infer_signature_input_torch(outputs), infer_signature_input_torch(outputs))
+    signature = infer_signature(infer_signature_input(outputs), infer_signature_input(outputs))
 
     assert check_signature_equality(signature.outputs.inputs, expected_output_signature)
 
@@ -151,9 +151,9 @@ def test_nested_list_signature():
 
     # Nested structures are not supported
     with raises(ValueError):
-        infer_signature_input_torch(inputs)
+        infer_signature_input(inputs)
 
-    signature = infer_signature(infer_signature_input_torch(outputs), infer_signature_input_torch(outputs))
+    signature = infer_signature(infer_signature_input(outputs), infer_signature_input(outputs))
 
     assert check_signature_equality(signature.outputs.inputs, expected_output_signature)
 
@@ -170,10 +170,10 @@ def test_nested_dicts_signature():
 
     # Nested structures are not supported
     with raises(ValueError):
-        infer_signature_input_torch(inputs)
+        infer_signature_input(inputs)
 
     with raises(ValueError):
-        infer_signature_input_torch(outputs)
+        infer_signature_input(outputs)
 
 
 @torch.inference_mode()
@@ -189,7 +189,7 @@ def test_tuple_of_dicts_signature():
 
     # Nested structures are not supported
     with raises(ValueError):
-        infer_signature_input_torch(inputs)
+        infer_signature_input(inputs)
 
     with raises(ValueError):
-        infer_signature_input_torch(outputs)
+        infer_signature_input(outputs)

--- a/tests/utilities/test_mlflow_export.py
+++ b/tests/utilities/test_mlflow_export.py
@@ -18,7 +18,7 @@ from pytest import raises
 
 from quadra.models.base import ModelSignatureWrapper
 from quadra.utils.export import generate_torch_inputs
-from quadra.utils.mlflow import infer_signature_input_torch, infer_signature_torch_model
+from quadra.utils.mlflow import infer_signature_model
 from quadra.utils.tests.models import DoubleInputModel, SingleInputModel
 
 
@@ -57,7 +57,7 @@ def test_single_tensor_signature():
 
     inputs = generate_torch_inputs(model.input_shapes, device="cpu")
 
-    signature = infer_signature_torch_model(model, inputs)
+    signature = infer_signature_model(model, inputs)
 
     expected_input_signature = [TensorSpec(shape=(-1, *x.shape[1:]), type=x.numpy().dtype)]
 
@@ -76,7 +76,7 @@ def test_multiple_tensor_signature():
     assert model.input_shapes == [(3, 224, 224), (3, 448, 448)]
     inputs = generate_torch_inputs(model.input_shapes, device="cpu")
 
-    signature = infer_signature_torch_model(model, inputs)
+    signature = infer_signature_model(model, inputs)
 
     expected_input_signature = [
         TensorSpec(shape=(-1, *x.shape[1:]), type=x.numpy().dtype, name="output_0"),
@@ -98,7 +98,7 @@ def test_dict_signature():
 
     inputs = generate_torch_inputs(model.input_shapes, device="cpu")
 
-    signature = infer_signature_torch_model(model, inputs)
+    signature = infer_signature_model(model, inputs)
 
     expected_input_signature = [TensorSpec(shape=(-1, *x.shape[1:]), type=x.numpy().dtype, name="x")]
 


### PR DESCRIPTION
## Summary

Describe the purpose of the pull request, including:

Now mlflow model log is optional (regulated by new core config parameter "upload_models").
Now also onnx and onnx simplified models can be logged on mlflow.
Now matplotlib backend is switched to 'Agg' during analysis report image plotting, to solve major slowdown issue on some machines.
Now also Segmentation prints number of samples of each split (without considering classes, given the one-hot encoding ugly format)

## Type of Change

- New feature (non-breaking change that adds functionality)
- Small Bug fix (non-breaking change that solves an issue)


## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.
![image](https://github.com/orobix/quadra/assets/61737239/3dc86300-ead5-418e-914d-949b15c17c7b)
