### PR TITLE
Remove support for pytorch mlflow upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [1.5.8]
+
+#### Fixed
+
+- Fix classification finetuning best ckpt usage during export
+
 ### [1.5.7]
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quadra"
-version = "1.5.7"
+version = "1.5.8"
 description = "Deep Learning experiment orchestration library"
 authors = [
   "Federico Belotti <federico.belotti@orobix.com>",

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.7"
+__version__ = "1.5.8"
 
 
 def get_version():

--- a/quadra/utils/export.py
+++ b/quadra/utils/export.py
@@ -5,6 +5,8 @@ import torch
 from anomalib.models.cflow import CflowLightning
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from torch import nn
+import hydra
+from omegaconf import DictConfig
 
 from quadra.models.base import ModelSignatureWrapper
 from quadra.models.evaluation import (

--- a/quadra/utils/utils.py
+++ b/quadra/utils/utils.py
@@ -1,11 +1,13 @@
 """Common utility functions.
 Some of them are mostly based on https://github.com/ashleve/lightning-hydra-template.
 """
+
 import glob
 import json
 import logging
 import os
 import subprocess
+from pathlib import Path
 import sys
 import warnings
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, cast
@@ -299,6 +301,10 @@ def finish(
                         logging.warning("%s model type not supported", model_path)
                         continue
                     if model_type is not None and model_type in types_to_upload:
+                        if model_type == "pytorch":
+                            logging.warning("Pytorch format still not supported for mlflow upload")
+                            continue
+
                         model = quadra_export.import_deployment_model(
                             model_path, device=device, inference_config=config.inference
                         )


### PR DESCRIPTION
## Summary

Skipping pytorch model-type mlflow upload.
Same bugfix of v2.0.1. 
This aligns with the objective of supporting quadra w/ PyTorch 1.13 within the v1.5.x branch

## Type of Change

Please select the one relevant option below:

- Bug fix (non-breaking change that solves an issue)
- New feature (non-breaking change that adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update
- Other (please describe):

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

