### PR TITLE
Refactor anomaly score computation

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,6 +1,13 @@
 # Breaking Changes
 All the breaking changes will be documented in this file.
 
+### [2.1.0]
+
+#### Changed
+
+- Change the way anomaly scores are normalized by default, instead of using a [0-1] range with a 0.5 threshold, the scores are now normalized to a [0-1000] range with a threshold of 100, the new score represents the distance from the selected threshold, for example, a score of 200 means that the anomaly score is 100% of the threshold above the threshold itself, a score of 50 means that the anomaly score is 50% of the threshold below. This change is intended to make the scores more interpretable and easier to understand, also it makes the score independent from the min and max
+scores in the dataset.
+
 ### [2.0.0]
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 #### Updated
 
 - Change the way anomaly scores are normalized by default, instead of using a [0-1] range with a 0.5 threshold, the scores are now normalized to a [0-1000] range with a threshold of 100, the new score represents the distance from the selected threshold, for example, a score of 200 means that the anomaly score is 100% of the threshold above the threshold itself, a score of 50 means that the anomaly score is 50% of the threshold below. 
+- Change the default normalization config name for anomaly from `min_max_normalization` to `score_normalization`.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [2.1.0]
+
+#### Updated
+
+- Change the way anomaly scores are normalized by default, instead of using a [0-1] range with a 0.5 threshold, the scores are now normalized to a [0-1000] range with a threshold of 100, the new score represents the distance from the selected threshold, for example, a score of 200 means that the anomaly score is 100% of the threshold above the threshold itself, a score of 50 means that the anomaly score is 50% of the threshold below. 
+
+#### Fixed
+
+- Fix the output heatmaps and preditions of anomaly inference tasks not being saved properly when images belonged to
+different classes but had the same name.
+
 ### [2.0.4]
 
 #### Fixed 

--- a/docs/tutorials/examples/anomaly_detection.md
+++ b/docs/tutorials/examples/anomaly_detection.md
@@ -105,8 +105,8 @@ What can be useful to customize are the default callbacks:
 ```yaml
 callbacks:
   # Anomalib specific callbacks
-  min_max_normalization:
-    _target_: anomalib.utils.callbacks.min_max_normalization.MinMaxNormalizationCallback
+  threshold_normalization:
+    _target_: quadra.utils.anomaly.ThresholdNormalizationCallback
     threshold_type: image
   post_processing_configuration:
     _target_: anomalib.utils.callbacks.post_processing_configuration.PostProcessingConfigurationCallback
@@ -122,7 +122,7 @@ callbacks:
     _target_: quadra.callbacks.anomalib.VisualizerCallback
     inputs_are_normalized: true
     output_path: anomaly_output
-    threshold_type: ${callbacks.min_max_normalization.threshold_type}
+    threshold_type: ${callbacks.threshold_normalization.threshold_type}
     disable: true
     plot_only_wrong: false
     plot_raw_outputs: false
@@ -140,13 +140,13 @@ callbacks:
 
     By default lightning batch_size_finder callback is disabled. This callback will automatically try to infer the maximum batch size that can be used for training without running out of memory. We've experimented runtime errors with this callback on some machines due to a Pytorch/CUDNN incompatibility so be careful when using it.
 
-The min_max_normalization callback is used to normalize the anomaly maps to the range [0, 1] such that the threshold will become 0.5. 
+The threshold_normalization callback is used to normalize the anomaly maps to the range [0, 1000] such that the threshold will become 100.
 
 The threshold_type can be either "image" or "pixel" and it indicates which threshold to use to normalize the pixel level threshold, if no masks are available for segmentation this should always be "image", otherwise the normalization will use the threshold computed without masks which would result in wrong segmentations.
 
 The post processing configuration allow to specify the method used to compute the threshold, methods and manual metrics are generally specified in the model configuration and should not be changed here.
 
-The visualizer callback is used to produce a visualization of the results on the test data, when the min_max_normalization callback is used the input_are_normalized flag must be set to true and the threshold_type should match the one used for normalization. By default it is disabled as it may take a while to compute, to enable just set `disable: false`.
+The visualizer callback is used to produce a visualization of the results on the test data, when the threshold_normalization callback is used the input_are_normalized flag must be set to true and the threshold_type should match the one used for normalization. By default it is disabled as it may take a while to compute, to enable just set `disable: false`.
 
 In the context where many images are supplied to our model, we may be more interested in restricting the output images that are generated to only the cases where the result is not correct. By default it is disabled, to enable just set `plot_only_wrong: true`.
 
@@ -224,7 +224,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "image"
 
 print_config: false

--- a/docs/tutorials/examples/anomaly_detection.md
+++ b/docs/tutorials/examples/anomaly_detection.md
@@ -105,7 +105,7 @@ What can be useful to customize are the default callbacks:
 ```yaml
 callbacks:
   # Anomalib specific callbacks
-  threshold_normalization:
+  score_normalization:
     _target_: quadra.utils.anomaly.ThresholdNormalizationCallback
     threshold_type: image
   post_processing_configuration:
@@ -122,7 +122,7 @@ callbacks:
     _target_: quadra.callbacks.anomalib.VisualizerCallback
     inputs_are_normalized: true
     output_path: anomaly_output
-    threshold_type: ${callbacks.threshold_normalization.threshold_type}
+    threshold_type: ${callbacks.score_normalization.threshold_type}
     disable: true
     plot_only_wrong: false
     plot_raw_outputs: false
@@ -140,13 +140,13 @@ callbacks:
 
     By default lightning batch_size_finder callback is disabled. This callback will automatically try to infer the maximum batch size that can be used for training without running out of memory. We've experimented runtime errors with this callback on some machines due to a Pytorch/CUDNN incompatibility so be careful when using it.
 
-The threshold_normalization callback is used to normalize the anomaly maps to the range [0, 1000] such that the threshold will become 100.
+The score_normalization callback is used to normalize the anomaly maps to the range [0, 1000] such that the threshold will become 100.
 
 The threshold_type can be either "image" or "pixel" and it indicates which threshold to use to normalize the pixel level threshold, if no masks are available for segmentation this should always be "image", otherwise the normalization will use the threshold computed without masks which would result in wrong segmentations.
 
 The post processing configuration allow to specify the method used to compute the threshold, methods and manual metrics are generally specified in the model configuration and should not be changed here.
 
-The visualizer callback is used to produce a visualization of the results on the test data, when the threshold_normalization callback is used the input_are_normalized flag must be set to true and the threshold_type should match the one used for normalization. By default it is disabled as it may take a while to compute, to enable just set `disable: false`.
+The visualizer callback is used to produce a visualization of the results on the test data, when the score_normalization callback is used the input_are_normalized flag must be set to true and the threshold_type should match the one used for normalization. By default it is disabled as it may take a while to compute, to enable just set `disable: false`.
 
 In the context where many images are supplied to our model, we may be more interested in restricting the output images that are generated to only the cases where the result is not correct. By default it is disabled, to enable just set `plot_only_wrong: true`.
 
@@ -224,7 +224,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "image"
 
 print_config: false

--- a/poetry.lock
+++ b/poetry.lock
@@ -2952,7 +2952,7 @@ files = [
 cssselect = ["cssselect (>=0.7)"]
 html5 = ["html5lib"]
 htmlsoup = ["BeautifulSoup4"]
-source = ["Cython (>=3.0.7)"]
+source = ["Cython (>=3.0.8)"]
 
 [[package]]
 name = "mako"
@@ -5412,7 +5412,7 @@ files = [
 [[package]]
 name = "pyyaml-env-tag"
 version = "0.1"
-description = "A custom YAML tag for referencing environment variables in YAML files. "
+description = "A custom YAML tag for referencing environment variables in YAML files."
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -6048,7 +6048,6 @@ description = "Scikit-multilearn is a BSD-licensed library for multi-label class
 optional = false
 python-versions = "*"
 files = [
-    {file = "scikit-multilearn-0.2.0.linux-x86_64.tar.gz", hash = "sha256:3179fed29b1492f6a69600696c23045b9f494d2b89d1796a8bdc43ccbb33712b"},
     {file = "scikit_multilearn-0.2.0-py2-none-any.whl", hash = "sha256:0a389600a6797db6567f2f6ca1d0dca30bebfaaa73f75de62d7ae40f8f03d4fb"},
     {file = "scikit_multilearn-0.2.0-py3-none-any.whl", hash = "sha256:068c652f22704a084ca252d05d21a655e7c9b248d0a4543847b74de5fca2b3f0"},
 ]
@@ -6192,7 +6191,7 @@ huey = ["huey (>=2)"]
 loguru = ["loguru (>=0.5)"]
 opentelemetry = ["opentelemetry-distro (>=0.35b0)"]
 opentelemetry-experimental = ["opentelemetry-distro (>=0.40b0,<1.0)", "opentelemetry-instrumentation-aiohttp-client (>=0.40b0,<1.0)", "opentelemetry-instrumentation-django (>=0.40b0,<1.0)", "opentelemetry-instrumentation-fastapi (>=0.40b0,<1.0)", "opentelemetry-instrumentation-flask (>=0.40b0,<1.0)", "opentelemetry-instrumentation-requests (>=0.40b0,<1.0)", "opentelemetry-instrumentation-sqlite3 (>=0.40b0,<1.0)", "opentelemetry-instrumentation-urllib (>=0.40b0,<1.0)"]
-pure-eval = ["asttokens", "executing", "pure_eval"]
+pure-eval = ["asttokens", "executing", "pure-eval"]
 pymongo = ["pymongo (>=3.1)"]
 pyspark = ["pyspark (>=2.4.4)"]
 quart = ["blinker (>=1.1)", "quart (>=0.16.1)"]
@@ -6496,7 +6495,7 @@ typing-extensions = ">=4.6.0"
 [package.extras]
 aiomysql = ["aiomysql (>=0.2.0)", "greenlet (!=0.4.17)"]
 aioodbc = ["aioodbc", "greenlet (!=0.4.17)"]
-aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing_extensions (!=3.10.0.1)"]
+aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing-extensions (!=3.10.0.1)"]
 asyncio = ["greenlet (!=0.4.17)"]
 asyncmy = ["asyncmy (>=0.2.3,!=0.2.4,!=0.2.6)", "greenlet (!=0.4.17)"]
 mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2,!=1.1.5)"]
@@ -6506,7 +6505,7 @@ mssql-pyodbc = ["pyodbc"]
 mypy = ["mypy (>=0.910)"]
 mysql = ["mysqlclient (>=1.4.0)"]
 mysql-connector = ["mysql-connector-python"]
-oracle = ["cx_oracle (>=8)"]
+oracle = ["cx-oracle (>=8)"]
 oracle-oracledb = ["oracledb (>=1.0.1)"]
 postgresql = ["psycopg2 (>=2.7)"]
 postgresql-asyncpg = ["asyncpg", "greenlet (!=0.4.17)"]
@@ -6516,7 +6515,7 @@ postgresql-psycopg2binary = ["psycopg2-binary"]
 postgresql-psycopg2cffi = ["psycopg2cffi"]
 postgresql-psycopgbinary = ["psycopg[binary] (>=3.0.7)"]
 pymysql = ["pymysql"]
-sqlcipher = ["sqlcipher3_binary"]
+sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
 name = "sqlparse"
@@ -7086,13 +7085,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.11.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
-    {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},
+    {file = "typing_extensions-4.11.0-py3-none-any.whl", hash = "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"},
+    {file = "typing_extensions-4.11.0.tar.gz", hash = "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"},
 ]
 
 [[package]]
@@ -7830,4 +7829,4 @@ onnx = ["onnx", "onnxruntime_gpu", "onnxsim"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.11"
-content-hash = "71b257f752974e3c002c0a4027a9faf5c5a99ae2eac9704e668393b6c2c53299"
+content-hash = "fb91a2b045cb6f2b02e6d9f9814ad2d3a287ec60af595ec8f1467ba0e3503359"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7829,4 +7829,4 @@ onnx = ["onnx", "onnxruntime_gpu", "onnxsim"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.11"
-content-hash = "fb91a2b045cb6f2b02e6d9f9814ad2d3a287ec60af595ec8f1467ba0e3503359"
+content-hash = "573f1a7c2d46ae89ff81f9658d45a306a63995006b867151ccff5c360c958775"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quadra"
-version = "2.0.4"
+version = "2.1.0"
 description = "Deep Learning experiment orchestration library"
 authors = [
   "Federico Belotti <federico.belotti@orobix.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ segmentation_models_pytorch = { git = "https://github.com/qubvel/segmentation_mo
 anomalib = { git = "https://github.com/orobix/anomalib.git", tag = "v0.7.0+obx.1.3.0" }
 xxhash = "~3.2"
 torchinfo = "~1.8"
-typing_extensions = { version = "4.11.0", optional = true, python = "<3.10" }
+typing_extensions = { version = "4.11.0", python = "<3.10" }
 
 # ONNX dependencies
 onnx = { version = "1.15.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ segmentation_models_pytorch = { git = "https://github.com/qubvel/segmentation_mo
 anomalib = { git = "https://github.com/orobix/anomalib.git", tag = "v0.7.0+obx.1.3.0" }
 xxhash = "~3.2"
 torchinfo = "~1.8"
+typing_extensions = { version = "4.11.0", optional = true, python = "<3.10" }
 
 # ONNX dependencies
 onnx = { version = "1.15.0", optional = true }

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.4"
+__version__ = "2.1.0"
 
 
 def get_version():

--- a/quadra/callbacks/anomalib.py
+++ b/quadra/callbacks/anomalib.py
@@ -92,7 +92,7 @@ class VisualizerCallback(Callback):
     Args:
         task: either 'segmentation' or 'classification'
         output_path: location where the images will be saved.
-        inputs_are_normalized: whether the input images are normalized (i.e using MinMax callback).
+        inputs_are_normalized: whether the input images are normalized (like when using MinMax or Treshold callback).
         threshold_type: Either 'pixel' or 'image'. If 'pixel', the threshold is computed on the pixel-level.
         disable: whether to disable the callback.
         plot_only_wrong: whether to plot only the images that are not correctly predicted.

--- a/quadra/configs/callbacks/default_anomalib.yaml
+++ b/quadra/configs/callbacks/default_anomalib.yaml
@@ -1,6 +1,6 @@
 # Anomalib specific callbacks
-min_max_normalization:
-  _target_: anomalib.utils.callbacks.min_max_normalization.MinMaxNormalizationCallback
+threshold_normalization:
+  _target_: quadra.utils.anomaly.ThresholdNormalizationCallback
   threshold_type: image
 post_processing_configuration:
   _target_: anomalib.utils.callbacks.post_processing_configuration.PostProcessingConfigurationCallback
@@ -16,7 +16,7 @@ visualizer:
   _target_: quadra.callbacks.anomalib.VisualizerCallback
   inputs_are_normalized: true
   output_path: anomaly_output
-  threshold_type: ${callbacks.min_max_normalization.threshold_type}
+  threshold_type: ${callbacks.threshold_normalization.threshold_type}
   disable: true
   plot_only_wrong: false
   plot_raw_outputs: false

--- a/quadra/configs/callbacks/default_anomalib.yaml
+++ b/quadra/configs/callbacks/default_anomalib.yaml
@@ -1,5 +1,5 @@
 # Anomalib specific callbacks
-threshold_normalization:
+score_normalization:
   _target_: quadra.utils.anomaly.ThresholdNormalizationCallback
   threshold_type: image
 post_processing_configuration:
@@ -16,7 +16,7 @@ visualizer:
   _target_: quadra.callbacks.anomalib.VisualizerCallback
   inputs_are_normalized: true
   output_path: anomaly_output
-  threshold_type: ${callbacks.threshold_normalization.threshold_type}
+  threshold_type: ${callbacks.score_normalization.threshold_type}
   disable: true
   plot_only_wrong: false
   plot_raw_outputs: false

--- a/quadra/configs/experiment/generic/mnist/anomaly/cfa.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/cfa.yaml
@@ -11,7 +11,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "image"
   early_stopping:
     patience: 2

--- a/quadra/configs/experiment/generic/mnist/anomaly/cfa.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/cfa.yaml
@@ -11,7 +11,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "image"
   early_stopping:
     patience: 2

--- a/quadra/configs/experiment/generic/mnist/anomaly/cflow.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/cflow.yaml
@@ -10,7 +10,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "image"
   early_stopping:
     patience: 2

--- a/quadra/configs/experiment/generic/mnist/anomaly/cflow.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/cflow.yaml
@@ -10,7 +10,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "image"
   early_stopping:
     patience: 2

--- a/quadra/configs/experiment/generic/mnist/anomaly/csflow.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/csflow.yaml
@@ -10,7 +10,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "image"
   early_stopping:
     patience: 3

--- a/quadra/configs/experiment/generic/mnist/anomaly/csflow.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/csflow.yaml
@@ -10,7 +10,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "image"
   early_stopping:
     patience: 3

--- a/quadra/configs/experiment/generic/mnist/anomaly/draem.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/draem.yaml
@@ -10,7 +10,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "image"
   early_stopping:
     patience: 20

--- a/quadra/configs/experiment/generic/mnist/anomaly/draem.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/draem.yaml
@@ -10,7 +10,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "image"
   early_stopping:
     patience: 20

--- a/quadra/configs/experiment/generic/mnist/anomaly/fastflow.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/fastflow.yaml
@@ -10,7 +10,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "image"
 print_config: false
 

--- a/quadra/configs/experiment/generic/mnist/anomaly/fastflow.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/fastflow.yaml
@@ -10,7 +10,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "image"
 print_config: false
 

--- a/quadra/configs/experiment/generic/mnist/anomaly/padim.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/padim.yaml
@@ -15,7 +15,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "image"
 
 print_config: false

--- a/quadra/configs/experiment/generic/mnist/anomaly/padim.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/padim.yaml
@@ -15,7 +15,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "image"
 
 print_config: false

--- a/quadra/configs/experiment/generic/mnist/anomaly/patchcore.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/patchcore.yaml
@@ -15,7 +15,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "image"
 
 print_config: false

--- a/quadra/configs/experiment/generic/mnist/anomaly/patchcore.yaml
+++ b/quadra/configs/experiment/generic/mnist/anomaly/patchcore.yaml
@@ -15,7 +15,7 @@ datamodule:
   good_number: 9
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "image"
 
 print_config: false

--- a/quadra/configs/experiment/generic/mvtec/anomaly/cfa.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/cfa.yaml
@@ -11,7 +11,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "pixel"
   early_stopping:
     patience: 2

--- a/quadra/configs/experiment/generic/mvtec/anomaly/cfa.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/cfa.yaml
@@ -11,7 +11,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "pixel"
   early_stopping:
     patience: 2

--- a/quadra/configs/experiment/generic/mvtec/anomaly/cflow.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/cflow.yaml
@@ -10,7 +10,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "pixel"
   early_stopping:
     patience: 2

--- a/quadra/configs/experiment/generic/mvtec/anomaly/cflow.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/cflow.yaml
@@ -10,7 +10,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "pixel"
   early_stopping:
     patience: 2

--- a/quadra/configs/experiment/generic/mvtec/anomaly/csflow.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/csflow.yaml
@@ -10,7 +10,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "pixel"
   early_stopping:
     patience: 3

--- a/quadra/configs/experiment/generic/mvtec/anomaly/csflow.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/csflow.yaml
@@ -10,7 +10,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "pixel"
   early_stopping:
     patience: 3

--- a/quadra/configs/experiment/generic/mvtec/anomaly/draem.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/draem.yaml
@@ -10,7 +10,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "pixel"
   early_stopping:
     patience: 20

--- a/quadra/configs/experiment/generic/mvtec/anomaly/draem.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/draem.yaml
@@ -10,7 +10,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "pixel"
   early_stopping:
     patience: 20

--- a/quadra/configs/experiment/generic/mvtec/anomaly/efficient_ad.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/efficient_ad.yaml
@@ -15,7 +15,7 @@ datamodule:
   category: hazelnut
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "pixel"
 
 print_config: false

--- a/quadra/configs/experiment/generic/mvtec/anomaly/efficient_ad.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/efficient_ad.yaml
@@ -15,7 +15,7 @@ datamodule:
   category: hazelnut
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "pixel"
 
 print_config: false

--- a/quadra/configs/experiment/generic/mvtec/anomaly/fastflow.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/fastflow.yaml
@@ -10,7 +10,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "pixel"
 print_config: false
 

--- a/quadra/configs/experiment/generic/mvtec/anomaly/fastflow.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/fastflow.yaml
@@ -10,7 +10,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "pixel"
 print_config: false
 

--- a/quadra/configs/experiment/generic/mvtec/anomaly/padim.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/padim.yaml
@@ -15,7 +15,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "pixel"
 
 print_config: false

--- a/quadra/configs/experiment/generic/mvtec/anomaly/padim.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/padim.yaml
@@ -15,7 +15,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "pixel"
 
 print_config: false

--- a/quadra/configs/experiment/generic/mvtec/anomaly/patchcore.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/patchcore.yaml
@@ -15,7 +15,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  threshold_normalization:
+  score_normalization:
     threshold_type: "pixel"
 
 print_config: false

--- a/quadra/configs/experiment/generic/mvtec/anomaly/patchcore.yaml
+++ b/quadra/configs/experiment/generic/mvtec/anomaly/patchcore.yaml
@@ -15,7 +15,7 @@ datamodule:
   category: bottle
 
 callbacks:
-  min_max_normalization:
+  threshold_normalization:
     threshold_type: "pixel"
 
 print_config: false

--- a/quadra/utils/anomaly.py
+++ b/quadra/utils/anomaly.py
@@ -1,0 +1,104 @@
+"""Anomaly Score Normalization Callback that uses min-max normalization."""
+
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any, TypeAlias
+
+# MyPy wants TypeAlias, but pylint has problems dealing with it
+import numpy as np  # pylint: disable=unused-import
+import pytorch_lightning as pl
+import torch  # pylint: disable=unused-import
+from anomalib.models.components import AnomalyModule
+from pytorch_lightning import Callback
+from pytorch_lightning.utilities.types import STEP_OUTPUT
+
+# https://github.com/python/cpython/issues/90015#issuecomment-1172996118
+MapOrValue: TypeAlias = "float | torch.Tensor | np.ndarray"
+
+
+def normalize_anomaly_score(raw_score: MapOrValue, threshold: float) -> MapOrValue:
+    """Normalize anomaly score value or map based on threshold.
+
+    Args:
+        raw_score: Raw anomaly score valure or map
+        threshold: Threshold for anomaly detection
+
+    Returns:
+        Normalized anomaly score value or map clipped between 0 and 1000
+    """
+    if threshold > 0:
+        normalized_score = (raw_score / threshold) * 100.0
+    elif threshold == 0:
+        # TODO: Is this the best way to handle this case?
+        normalized_score = (raw_score + 1) * 100.0
+    else:
+        normalized_score = 200.0 - ((raw_score / threshold) * 100.0)
+
+    if isinstance(normalized_score, torch.Tensor):
+        return torch.clamp(normalized_score, 0.0, 1000.0)
+
+    return np.clip(normalized_score, 0.0, 1000.0)
+
+
+class ThresholdNormalizationCallback(Callback):
+    """Callback that normalizes the image-level and pixel-level anomaly scores dividing by the threshold value.
+
+    Args:
+        threshold_type: Threshold used to normalize pixel level anomaly scores, either image or pixel (default)
+    """
+
+    def __init__(self, threshold_type: str = "pixel"):
+        super().__init__()
+        self.threshold_type = threshold_type
+
+    def on_test_start(self, trainer: pl.Trainer, pl_module: AnomalyModule) -> None:
+        """Called when the test begins."""
+        del trainer  # `trainer` variable is not used.
+
+        for metric in (pl_module.image_metrics, pl_module.pixel_metrics):
+            if metric is not None:
+                metric.set_threshold(100.0)
+
+    def on_test_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: AnomalyModule,
+        outputs: STEP_OUTPUT | None,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Called when the test batch ends, normalizes the predicted scores and anomaly maps."""
+        del trainer, batch, batch_idx, dataloader_idx  # These variables are not used.
+
+        self._normalize_batch(outputs, pl_module)
+
+    def on_predict_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: AnomalyModule,
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Called when the predict batch ends, normalizes the predicted scores and anomaly maps."""
+        del trainer, batch, batch_idx, dataloader_idx  # These variables are not used.
+
+        self._normalize_batch(outputs, pl_module)
+
+    def _normalize_batch(self, outputs, pl_module):
+        """Normalize a batch of predictions."""
+        image_threshold = pl_module.image_threshold.value.cpu()
+        pixel_threshold = pl_module.pixel_threshold.value.cpu()
+        outputs["pred_scores"] = normalize_anomaly_score(outputs["pred_scores"], image_threshold)
+
+        threshold = pixel_threshold if self.threshold_type == "pixel" else image_threshold
+        if "anomaly_maps" in outputs.keys():
+            outputs["anomaly_maps"] = normalize_anomaly_score(outputs["anomaly_maps"], threshold)
+
+        if "box_scores" in outputs:
+            outputs["box_scores"] = [normalize_anomaly_score(scores, threshold) for scores in outputs["box_scores"]]

--- a/quadra/utils/anomaly.py
+++ b/quadra/utils/anomaly.py
@@ -5,7 +5,13 @@
 
 from __future__ import annotations
 
-from typing import Any, TypeAlias
+try:
+    from typing import Any, TypeAlias
+except ImportError:
+    from typing import Any
+
+    from typing_extensions import TypeAlias
+
 
 # MyPy wants TypeAlias, but pylint has problems dealing with it
 import numpy as np  # pylint: disable=unused-import


### PR DESCRIPTION
## Summary

Describe the purpose of the pull request, including:

Change the way anomaly scores are normalized by default, instead of using a [0-1] range with a 0.5 threshold, the scores are now normalized to a [0-1000] range with a threshold of 100, the new score represents the distance from the selected threshold, for example, a score of 200 means that the anomaly score is 100% of the threshold above the threshold itself, a score of 50 means that the anomaly score is 50% of the threshold below. This change is intended to make the scores more interpretable and easier to understand, also it makes the score independent from the min and max
scores in the dataset.

## Type of Change

Please select the one relevant option below:

- Breaking change 


## Checklist

Please confirm that the following tasks have been completed:

- [X] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [X] I have added unit tests for my changes, or updated existing tests if necessary.
- [X] I have updated the documentation, if applicable.
- [X] I have installed pre-commit and run locally for my code changes.