### PR TITLE
Feat/refactor anomaly test output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [2.1.1]
+
+#### Updated
+
+- Anomaly test task now exports results based on the normalized anomaly scores instead of the raw scores. The normalized anomaly scores and the optimal threshold are computed based on the training threshold of the model.
+
 ### [2.1.0]
 
 #### Updated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quadra"
-version = "2.1.0"
+version = "2.1.1"
 description = "Deep Learning experiment orchestration library"
 authors = [
   "Federico Belotti <federico.belotti@orobix.com>",

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 
 def get_version():


### PR DESCRIPTION
## Summary

In 2.1.0 we introduced the usage of the normalized anomaly score for anomaly detection, this score is now the preferred way to work.

In order to remove the necessity of a double threshold (one for the model and one for normalized score) the goal is to unify these concepts so that the model training threshold is fixed, while the normalized threshold can vary and is used as decision boundary.

While it's a breaking change it can be seen as part of the 2.1.0 refactoring :)

## Type of Change

Please select the one relevant option below:

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

Please confirm that the following tasks have been completed:

- [X] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [X] I have added unit tests for my changes, or updated existing tests if necessary.
- [X] I have updated the documentation, if applicable.
- [X] I have installed pre-commit and run locally for my code changes.
