### PR TITLE
Fix broken anomaly visualizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [2.1.10]
+
+#### Fixed
+
+- Fix anomaly visualizer callback showing wrong heatmaps after anomaly score refactoring
+
 ### [2.1.9]
 
 #### Updated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quadra"
-version = "2.1.9"
+version = "2.1.10"
 description = "Deep Learning experiment orchestration library"
 authors = [
 	"Federico Belotti <federico.belotti@orobix.com>",

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.9"
+__version__ = "2.1.10"
 
 
 def get_version():


### PR DESCRIPTION
## Summary

The latest changes to the normalization of anomaly score are causing a bug in the visualization of the heatmap made by the visualizer callback, to solve the issue the anomaly maps are properly rescaled in [0-1] range to properly impose them over the image.

## Type of Change

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.

## Screenshots or Visuals 

Before the fix
![Before](https://github.com/orobix/quadra/assets/14907613/47d57afe-435a-4bc7-85cb-672f1ab85e8b)

After the fix
![After](https://github.com/orobix/quadra/assets/14907613/79130693-4b0c-4268-afe1-7ec6702959bd)


