### PR TITLE
Hotfix/fix automatic batch size onnx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [2.1.11]
+
+#### Fixed
+
+- Fix sklearn automatic batch finder not working properly with ONNX backbones
+
 ### [2.1.10]
 
 #### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quadra"
-version = "2.1.10"
+version = "2.1.11"
 description = "Deep Learning experiment orchestration library"
 authors = [
 	"Federico Belotti <federico.belotti@orobix.com>",

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.10"
+__version__ = "2.1.11"
 
 
 def get_version():

--- a/quadra/utils/classification.py
+++ b/quadra/utils/classification.py
@@ -601,11 +601,12 @@ def automatic_batch_size_computation(
             log.info("Trying batch size: %d", datamodule.batch_size)
             _ = get_feature(feature_extractor=backbone, dl=base_dataloader, iteration_over_training=1, limit_batches=1)
         except RuntimeError as e:
-            if "CUDA out of memory" in str(e):
+            if batch_size > 1:
                 batch_size = batch_size // 2
                 optimal = False
                 continue
 
+            log.error("Unable to run the model with batch size 1")
             raise e
 
         log.info("Found optimal batch size: %d", datamodule.batch_size)


### PR DESCRIPTION
## Summary

When running the automatic batch size computation using an ONNX backbone for sklear based classification task, if an OOM occoured it is not catched properly causing an unhandled runtime error.

## Type of Change

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [X] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [X] I have added unit tests for my changes, or updated existing tests if necessary.
- [X] I have updated the documentation, if applicable.
- [X] I have installed pre-commit and run locally for my code changes.