### PR TITLE
Improve sklearn automatic batch size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [2.1.13]
+
+- Improve safe batch size computation for sklearn based classification tasks
+
 ### [2.1.12]
 
 #### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quadra"
-version = "2.1.12"
+version = "2.1.13"
 description = "Deep Learning experiment orchestration library"
 authors = [
 	"Federico Belotti <federico.belotti@orobix.com>",

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.12"
+__version__ = "2.1.13"
 
 
 def get_version():


### PR DESCRIPTION
## Summary

The current automatic batch size computation seems to work nicely, but there are cases where the chosen batch size is just big enough so that it's sufficient to store another tensor on gpu to cause OOM issues.
To overcome this issue the train/test of the sklearn classification have been changed to use a decorator that safely retries the functions with different batch sizes (the same function was already applied for the evaluation task).

## Type of Change

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [X] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [X] I have added unit tests for my changes, or updated existing tests if necessary.
- [X] I have updated the documentation, if applicable.
- [X] I have installed pre-commit and run locally for my code changes.
