### PR TITLE
Torch 2.6.0 upgrade

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,36 +16,34 @@ defaults:
 
 jobs:
   tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.10"]
+    container:
+      image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu20.04
     timeout-minutes: 60
     steps:
-      - uses: nvidia/cuda:12.6.3-cudnn-devel-ubuntu20.04
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Set up machine
+      - name: Set up system dependencies
         run: |
           export DEBIAN_FRONTEND=noninteractive
-          apt-get update && apt-get install ffmpeg libsm6 libxext6 curl ssh wget git -y
-          apt install software-properties-common -y
+          apt-get update && apt-get install -y \
+            ffmpeg libsm6 libxext6 curl ssh wget git \
+            software-properties-common
+
           add-apt-repository ppa:deadsnakes/ppa -y
           apt-get update
-          apt-get install python3.10 python3.10-dev python3.10-venv -y
-          export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
-          curl -sSL https://install.python-poetry.org | python3.10 - --version 2.1.2
-          export PATH="/root/.local/bin:$PATH"
-          # Setup cusparselt or torch will not work properly
+          apt-get install -y python3.10 python3.10-dev python3.10-venv
+
+          # Setup cusparselt
           wget https://developer.download.nvidia.com/compute/cusparselt/0.7.1/local_installers/cusparselt-local-repo-ubuntu2004-0.7.1_1.0-1_amd64.deb
           dpkg -i cusparselt-local-repo-ubuntu2004-0.7.1_1.0-1_amd64.deb
           cp /var/cusparselt-local-repo-ubuntu2004-0.7.1/cusparselt-*-keyring.gpg /usr/share/keyrings/
           apt-get update
           apt-get install -y libcusparselt0
-      - name: Install Package
+
+      - name: Install Poetry and dependencies
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
+          curl -sSL https://install.python-poetry.org | python3.10 - --version 2.1.2
           export PATH="$HOME/.local/bin:$PATH"
           poetry install --no-cache --with test -E onnx
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ defaults:
 
 jobs:
   tests:
+    runs-on: ubuntu-latest
     container:
       image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu20.04
     timeout-minutes: 60

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,4 +50,5 @@ jobs:
 
       - name: Run Tests
         run: |
+          export PATH="$HOME/.local/bin:$PATH"
           poetry run pytest -v --disable-pytest-warnings --strict-markers --mock-training --color=yes -m "not slow"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,16 +24,25 @@ jobs:
         python-version: ["3.10"]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: nvidia/cuda:12.6.3-cudnn-devel-ubuntu20.04
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.txt
-            setup.py
+      - name: Set up machine
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update && apt-get install ffmpeg libsm6 libxext6 curl ssh wget git -y
+          apt install software-properties-common -y
+          add-apt-repository ppa:deadsnakes/ppa -y
+          apt-get update
+          apt-get install python3.10 python3.10-dev python3.10-venv -y
+          export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+          curl -sSL https://install.python-poetry.org | python3.10 - --version 2.1.2
+          export PATH="/root/.local/bin:$PATH"
+          # Setup cusparselt or torch will not work properly
+          wget https://developer.download.nvidia.com/compute/cusparselt/0.7.1/local_installers/cusparselt-local-repo-ubuntu2004-0.7.1_1.0-1_amd64.deb
+          dpkg -i cusparselt-local-repo-ubuntu2004-0.7.1_1.0-1_amd64.deb
+          cp /var/cusparselt-local-repo-ubuntu2004-0.7.1/cusparselt-*-keyring.gpg /usr/share/keyrings/
+          apt-get update
+          apt-get install -y libcusparselt0
       - name: Install Package
         run: |
           curl -sSL https://install.python-poetry.org | python3 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [2.4.0]
+
+#### Added
+
+- Add a way to use validation data to evaluate ONNX fp16 mixed precision export
+
+#### Updated
+
+- Update torch to 2.6.0+cu126 and torchvision to 0.21.0+cu126
+- Increase minimum rtol and atol for finetuning model export to avoid errors on efficientnet_b0 export
+
 ### [2.3.3]
 
 #### Updated

--- a/poetry.lock
+++ b/poetry.lock
@@ -3847,134 +3847,6 @@ files = [
 ]
 
 [[package]]
-name = "nvidia-cublas-cu12"
-version = "12.1.3.1"
-description = "CUBLAS native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:ee53ccca76a6fc08fb9701aa95b6ceb242cdaab118c3bb152af4e579af792728"},
-    {file = "nvidia_cublas_cu12-12.1.3.1-py3-none-win_amd64.whl", hash = "sha256:2b964d60e8cf11b5e1073d179d85fa340c120e99b3067558f3cf98dd69d02906"},
-]
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.1.105"
-description = "CUDA profiling tools runtime libs."
-optional = false
-python-versions = ">=3"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:e54fde3983165c624cb79254ae9818a456eb6e87a7fd4d56a2352c24ee542d7e"},
-    {file = "nvidia_cuda_cupti_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:bea8236d13a0ac7190bd2919c3e8e6ce1e402104276e6f9694479e48bb0eb2a4"},
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.1.105"
-description = "NVRTC native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:339b385f50c309763ca65456ec75e17bbefcbbf2893f462cb8b90584cd27a1c2"},
-    {file = "nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:0a98a522d9ff138b96c010a65e145dc1b4850e9ecb75a0172371793752fd46ed"},
-]
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.1.105"
-description = "CUDA Runtime native Libraries"
-optional = false
-python-versions = ">=3"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:6e258468ddf5796e25f1dc591a31029fa317d97a0a94ed93468fc86301d61e40"},
-    {file = "nvidia_cuda_runtime_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:dfb46ef84d73fababab44cf03e3b83f80700d27ca300e537f85f636fac474344"},
-]
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.1.0.70"
-description = "cuDNN runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl", hash = "sha256:165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f"},
-    {file = "nvidia_cudnn_cu12-9.1.0.70-py3-none-win_amd64.whl", hash = "sha256:6278562929433d68365a07a4a1546c237ba2849852c0d4b2262a486e805b977a"},
-]
-
-[package.dependencies]
-nvidia-cublas-cu12 = "*"
-
-[[package]]
-name = "nvidia-cufft-cu12"
-version = "11.0.2.54"
-description = "CUFFT native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl", hash = "sha256:794e3948a1aa71fd817c3775866943936774d1c14e7628c74f6f7417224cdf56"},
-    {file = "nvidia_cufft_cu12-11.0.2.54-py3-none-win_amd64.whl", hash = "sha256:d9ac353f78ff89951da4af698f80870b1534ed69993f10a4cf1d96f21357e253"},
-]
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.2.106"
-description = "CURAND native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:9d264c5036dde4e64f1de8c50ae753237c12e0b1348738169cd0f8a536c0e1e0"},
-    {file = "nvidia_curand_cu12-10.3.2.106-py3-none-win_amd64.whl", hash = "sha256:75b6b0c574c0037839121317e17fd01f8a69fd2ef8e25853d826fec30bdba74a"},
-]
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.4.5.107"
-description = "CUDA solver native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl", hash = "sha256:8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd"},
-    {file = "nvidia_cusolver_cu12-11.4.5.107-py3-none-win_amd64.whl", hash = "sha256:74e0c3a24c78612192a74fcd90dd117f1cf21dea4822e66d89e8ea80e3cd2da5"},
-]
-
-[package.dependencies]
-nvidia-cublas-cu12 = "*"
-nvidia-cusparse-cu12 = "*"
-nvidia-nvjitlink-cu12 = "*"
-
-[[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.1.0.106"
-description = "CUSPARSE native runtime libraries"
-optional = false
-python-versions = ">=3"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c"},
-    {file = "nvidia_cusparse_cu12-12.1.0.106-py3-none-win_amd64.whl", hash = "sha256:b798237e81b9719373e8fae8d4f091b70a0cf09d9d85c95a557e11df2d8e9a5a"},
-]
-
-[package.dependencies]
-nvidia-nvjitlink-cu12 = "*"
-
-[[package]]
 name = "nvidia-ml-py"
 version = "11.515.75"
 description = "Python Bindings for the NVIDIA Management Library"
@@ -3984,46 +3856,6 @@ groups = ["main"]
 files = [
     {file = "nvidia-ml-py-11.515.75.tar.gz", hash = "sha256:e3c75f06d5a3201dc51136e00e58c5c132b3be5d604d86c143426adb4e41c490"},
     {file = "nvidia_ml_py-11.515.75-py3-none-any.whl", hash = "sha256:5bf5f5240f5a242689c1d1129135a0bd79c8b93d2a282c7229fe32ab63e7999b"},
-]
-
-[[package]]
-name = "nvidia-nccl-cu12"
-version = "2.20.5"
-description = "NVIDIA Collective Communication Library (NCCL) Runtime"
-optional = false
-python-versions = ">=3"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "nvidia_nccl_cu12-2.20.5-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1fc150d5c3250b170b29410ba682384b14581db722b2531b0d8d33c595f33d01"},
-    {file = "nvidia_nccl_cu12-2.20.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:057f6bf9685f75215d0c53bf3ac4a10b3e6578351de307abad9e18a99182af56"},
-]
-
-[[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.8.61"
-description = "Nvidia JIT LTO Library"
-optional = false
-python-versions = ">=3"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:45fd79f2ae20bd67e8bc411055939049873bfd8fac70ff13bd4865e0b9bdab17"},
-    {file = "nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b80ecab31085dda3ce3b41d043be0ec739216c3fc633b8abe212d5a30026df0"},
-    {file = "nvidia_nvjitlink_cu12-12.8.61-py3-none-win_amd64.whl", hash = "sha256:1166a964d25fdc0eae497574d38824305195a5283324a21ccb0ce0c802cbf41c"},
-]
-
-[[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.1.105"
-description = "NVIDIA Tools Extension"
-optional = false
-python-versions = ">=3"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:dc21cf308ca5691e7c04d962e213f8a4aa9bbfa23d95412f452254c2caeb09e5"},
-    {file = "nvidia_nvtx_cu12-12.1.105-py3-none-win_amd64.whl", hash = "sha256:65f4d98982b31b60026e0e6de73fbdfc09d08a96f4656dd3665ca616a11e1e82"},
 ]
 
 [[package]]
@@ -6190,14 +6022,14 @@ pbr = ">=2.0.0"
 
 [[package]]
 name = "sympy"
-version = "1.13.3"
+version = "1.13.1"
 description = "Computer algebra system (CAS) in Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "sympy-1.13.3-py3-none-any.whl", hash = "sha256:54612cf55a62755ee71824ce692986f23c88ffa77207b30c1368eda4a7060f73"},
-    {file = "sympy-1.13.3.tar.gz", hash = "sha256:b27fd2c6530e0ab39e275fc9b683895367e51d5da91baa8d3d64db2565fec4d9"},
+    {file = "sympy-1.13.1-py3-none-any.whl", hash = "sha256:db36cdc64bf61b9b24578b6f7bab1ecdd2452cf008f34faa33776680c26d66f8"},
+    {file = "sympy-1.13.1.tar.gz", hash = "sha256:9cebf7e04ff162015ce31c9c6c9144daa34a93bd082f54fd8f12deca4f47515f"},
 ]
 
 [package.dependencies]
@@ -6427,22 +6259,29 @@ files = [
 
 [[package]]
 name = "torch"
-version = "2.4.1+cu121"
+version = "2.6.0+cu126"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.9.0"
 groups = ["main"]
 files = [
-    {file = "torch-2.4.1+cu121-cp310-cp310-linux_x86_64.whl", hash = "sha256:9a5f0b103cfe840b3568416aa5067f6e7b9fec67d9c5659fd43b1207450fe975"},
-    {file = "torch-2.4.1+cu121-cp310-cp310-win_amd64.whl", hash = "sha256:fe3bf682e86c08d6a8ec0ee30811732487fa688fc556d6e8f92d853d85507c0d"},
-    {file = "torch-2.4.1+cu121-cp311-cp311-linux_x86_64.whl", hash = "sha256:914d128e5abcbbe79ca1b9eb5311b185444f1b2d7117df555fe418487ecfb894"},
-    {file = "torch-2.4.1+cu121-cp311-cp311-win_amd64.whl", hash = "sha256:bc1e21d7412a2f06f552a9afb92c56c8b23d174884e9383259c3cf5db4687c98"},
-    {file = "torch-2.4.1+cu121-cp312-cp312-linux_x86_64.whl", hash = "sha256:ab491610b15551e08da74bab29d0933e6bf10bab44fb7d4b1328f1e845c05a53"},
-    {file = "torch-2.4.1+cu121-cp312-cp312-win_amd64.whl", hash = "sha256:b30faf3224697eaed131939690e8877b05b4d4cb6da5b12cfdcba3d742e9afd0"},
-    {file = "torch-2.4.1+cu121-cp38-cp38-linux_x86_64.whl", hash = "sha256:cb4f502f910b47e1e366ccf7b231dac2967d2efb47d4b8cb33fc63b4bc5eeed8"},
-    {file = "torch-2.4.1+cu121-cp38-cp38-win_amd64.whl", hash = "sha256:a48b991cd861266523cbed4705f89bef09669d5d2bbfa2524486156f74a222a8"},
-    {file = "torch-2.4.1+cu121-cp39-cp39-linux_x86_64.whl", hash = "sha256:9986ad3555ddfff55e925d8298f8b2b49106a7dc60f811a2076a445fe4458e2b"},
-    {file = "torch-2.4.1+cu121-cp39-cp39-win_amd64.whl", hash = "sha256:2ca012a78d7a2777c290a4b79cb2130bf65fdda89f533a8172674034c2a1519c"},
+    {file = "torch-2.6.0+cu126-cp310-cp310-linux_aarch64.whl", hash = "sha256:48775b8544e6705aa72256117f33c5f0c3c1ab51cb7abef1989dcfc3cf2e6500"},
+    {file = "torch-2.6.0+cu126-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c55280b4da58e565d8a25e0e844dc27d0c96aaada7b90b4de70a45397faf604e"},
+    {file = "torch-2.6.0+cu126-cp310-cp310-win_amd64.whl", hash = "sha256:eda7768f0a2ad9da3513abf60ff5c13049e7e2ec74ed4cfcd4736a8523ab1f89"},
+    {file = "torch-2.6.0+cu126-cp311-cp311-linux_aarch64.whl", hash = "sha256:d4809b188f5c9b9753f7578085b79ae1f5d9c36a3fffc122e83e446ecf251325"},
+    {file = "torch-2.6.0+cu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:cd3b15819315bd44d34e6fa56a8f6f64192608de17da112ec0cd6cd5fc1781f3"},
+    {file = "torch-2.6.0+cu126-cp311-cp311-win_amd64.whl", hash = "sha256:5ddca43b81c64df8ce0c59260566e648ee46b2622ab6a718e38dea3c0ca059a1"},
+    {file = "torch-2.6.0+cu126-cp312-cp312-linux_aarch64.whl", hash = "sha256:993e0e99c472df1d2746c3233ef8e88d992904fe75b8996a2c15439c43ff46c4"},
+    {file = "torch-2.6.0+cu126-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6bc5b9126daa3ac1e4d920b731da9f9503ff1f56204796de124e080f5cc3570e"},
+    {file = "torch-2.6.0+cu126-cp312-cp312-win_amd64.whl", hash = "sha256:b10c39c83e5d1afd639b5c9f5683b351e97e41390a93f59c59187004a9949924"},
+    {file = "torch-2.6.0+cu126-cp313-cp313-linux_aarch64.whl", hash = "sha256:e7913d9dcca60d352b296adf566ae9bb84c9e4d27414cf070b78a84c0a0ceb20"},
+    {file = "torch-2.6.0+cu126-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:2356c759696f4e296a7a08e8146c6381ccf2da40990fe400264b189a8a6c4bab"},
+    {file = "torch-2.6.0+cu126-cp313-cp313-win_amd64.whl", hash = "sha256:a1ce724eb9813fcd05b99cb8b652b2d02f447caba65f1469abd7d50af5e5323f"},
+    {file = "torch-2.6.0+cu126-cp313-cp313t-linux_aarch64.whl", hash = "sha256:e38a2564b15fba3fd8cb24d03d165b86a80fe3681b7207be5e500b100e19893c"},
+    {file = "torch-2.6.0+cu126-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:90d9c64ab8961595e05d4816e7190f38d8a1cd9931909a669da7bc398b9bc26b"},
+    {file = "torch-2.6.0+cu126-cp39-cp39-linux_aarch64.whl", hash = "sha256:2eea662d2d4ba57db2117d510c1baa47f49b1f327f9e91cf3a29d38f298d7f21"},
+    {file = "torch-2.6.0+cu126-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:eccdaa0908f91321f34d37d7286843ff7b32a8e187fdc61c97f8a895e636b19f"},
+    {file = "torch-2.6.0+cu126-cp39-cp39-win_amd64.whl", hash = "sha256:57ce9f680a4fe2ea0ecc0085e165fdedd2b333b34b6099b054b966d2ba169787"},
 ]
 
 [package.dependencies]
@@ -6450,29 +6289,17 @@ filelock = "*"
 fsspec = "*"
 jinja2 = "*"
 networkx = "*"
-nvidia-cublas-cu12 = {version = "12.1.3.1", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-cupti-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-nvrtc-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cuda-runtime-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cudnn-cu12 = {version = "9.1.0.70", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cufft-cu12 = {version = "11.0.2.54", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-curand-cu12 = {version = "10.3.2.106", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cusolver-cu12 = {version = "11.4.5.107", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-cusparse-cu12 = {version = "12.1.0.106", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-nccl-cu12 = {version = "2.20.5", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-nvidia-nvtx-cu12 = {version = "12.1.105", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""}
-sympy = "*"
-triton = {version = "3.0.0", markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""}
-typing-extensions = ">=4.8.0"
+sympy = {version = "1.13.1", markers = "python_version >= \"3.9\""}
+typing-extensions = ">=4.10.0"
 
 [package.extras]
 opt-einsum = ["opt-einsum (>=3.3)"]
-optree = ["optree (>=0.11.0)"]
+optree = ["optree (>=0.13.0)"]
 
 [package.source]
 type = "legacy"
-url = "https://download.pytorch.org/whl/cu121"
-reference = "torch_cu121"
+url = "https://download.pytorch.org/whl/cu126"
+reference = "torch_cu126"
 
 [[package]]
 name = "torchinfo"
@@ -6527,28 +6354,28 @@ files = [
 
 [[package]]
 name = "torchvision"
-version = "0.19.1+cu121"
+version = "0.21.0+cu126"
 description = "image and video datasets and models for torch deep learning"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "torchvision-0.19.1+cu121-cp310-cp310-linux_x86_64.whl", hash = "sha256:b8cc4bf381b75522995b601e07a1b433b5fd925dc3e34a7fa6cd22f449d65379"},
-    {file = "torchvision-0.19.1+cu121-cp310-cp310-win_amd64.whl", hash = "sha256:e530c6bbb72f587f0e94740758f005c99e6de871ed9d10afffd8f18bd41e5df0"},
-    {file = "torchvision-0.19.1+cu121-cp311-cp311-linux_x86_64.whl", hash = "sha256:536417340694b29cc54c308507d098b00cbdcc1fe868072a34b553bed73d9d30"},
-    {file = "torchvision-0.19.1+cu121-cp311-cp311-win_amd64.whl", hash = "sha256:952dedd29ddd6010b7bda16a5e58e55eb051a46db941cc676bb880918c694ed8"},
-    {file = "torchvision-0.19.1+cu121-cp312-cp312-linux_x86_64.whl", hash = "sha256:fb0cd0622e349df84ad73bad8ebbea6b1c74f033dadd84d9a80cf4a291927eae"},
-    {file = "torchvision-0.19.1+cu121-cp312-cp312-win_amd64.whl", hash = "sha256:a1627f99b9a7ac36f14d1ee207e71cf7ac52329c6317b580980fcc1916fe1276"},
-    {file = "torchvision-0.19.1+cu121-cp38-cp38-linux_x86_64.whl", hash = "sha256:3052f9722dc39fd7f026b44a6fbdef93ab28f7952007012ce84d313d67964011"},
-    {file = "torchvision-0.19.1+cu121-cp38-cp38-win_amd64.whl", hash = "sha256:7779b5dbe10994380d8baf5d7c754e6f57dac0f513009e003525f13a29f45491"},
-    {file = "torchvision-0.19.1+cu121-cp39-cp39-linux_x86_64.whl", hash = "sha256:14530dee0cc4c7c06024f0bdcc957f77de0d2b90e9b72219dcd621fa29525d00"},
-    {file = "torchvision-0.19.1+cu121-cp39-cp39-win_amd64.whl", hash = "sha256:5529733c7f8dc85c17499d5cd6d18e318d24334d06ba58d115157e94ae86a9bc"},
+    {file = "torchvision-0.21.0+cu126-cp310-cp310-linux_x86_64.whl", hash = "sha256:db4369a89b866b319c8dd73931c3e5f314aa535f7035ae2336ce9a26d7ace15a"},
+    {file = "torchvision-0.21.0+cu126-cp310-cp310-win_amd64.whl", hash = "sha256:d6b23af252e8f4fc923d57efeab5aad7a33b6e15a72a119d576aa48ec1e0d924"},
+    {file = "torchvision-0.21.0+cu126-cp311-cp311-linux_x86_64.whl", hash = "sha256:bce6bff7ad759a4c924214af08c04a6c1f6f2d2901031bfcf67fcbaa79c08432"},
+    {file = "torchvision-0.21.0+cu126-cp311-cp311-win_amd64.whl", hash = "sha256:ddbf4516fbb7624ac42934b877dcf6a3b295d9914ab89643b55dedb9c9773ce4"},
+    {file = "torchvision-0.21.0+cu126-cp312-cp312-linux_x86_64.whl", hash = "sha256:ec1887ed3c842aa48308ea00f1442c683f7d351fb14e94b76c2072678d06ac92"},
+    {file = "torchvision-0.21.0+cu126-cp312-cp312-win_amd64.whl", hash = "sha256:600c18579cd6eae8f6bbfcc43a088bc512bfde1fa4de0587a4db1d44eaf411f9"},
+    {file = "torchvision-0.21.0+cu126-cp313-cp313-linux_x86_64.whl", hash = "sha256:ed7912ed64c110792401273ee8a9dda81fc2ef53a66a3f7b25238bc52900a987"},
+    {file = "torchvision-0.21.0+cu126-cp313-cp313-win_amd64.whl", hash = "sha256:1112ebe400eca7af30060909ceec422708b2bb5ce470489c5ffb5cf93664779b"},
+    {file = "torchvision-0.21.0+cu126-cp39-cp39-linux_x86_64.whl", hash = "sha256:a73248e1620ca08842837955efb206019c9057b05c448806eed4fd269ca29f2d"},
+    {file = "torchvision-0.21.0+cu126-cp39-cp39-win_amd64.whl", hash = "sha256:783a78d0c52545df8c6f00e1048794526681680fe66ad60145010f0b2e1049ae"},
 ]
 
 [package.dependencies]
 numpy = "*"
 pillow = ">=5.3.0,<8.3.dev0 || >=8.4.dev0"
-torch = "2.4.1"
+torch = "2.6.0"
 
 [package.extras]
 gdown = ["gdown (>=4.7.3)"]
@@ -6556,8 +6383,8 @@ scipy = ["scipy"]
 
 [package.source]
 type = "legacy"
-url = "https://download.pytorch.org/whl/cu121"
-reference = "torch_cu121"
+url = "https://download.pytorch.org/whl/cu126"
+reference = "torch_cu126"
 
 [[package]]
 name = "tornado"
@@ -6629,30 +6456,6 @@ files = [
     {file = "tripy-1.0.0-py2.py3-none-any.whl", hash = "sha256:c6a8ea289e7526695edb87ac628d50f38342fbd7840b0ce27492238b65dd54d6"},
     {file = "tripy-1.0.0-py3-none-any.whl", hash = "sha256:13f861a47a2f6626137b55cf06b2a15d147bbfac7d80c53d59c5b557a59b24ec"},
 ]
-
-[[package]]
-name = "triton"
-version = "3.0.0"
-description = "A language and compiler for custom Deep Learning operations"
-optional = false
-python-versions = "*"
-groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
-files = [
-    {file = "triton-3.0.0-1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e1efef76935b2febc365bfadf74bcb65a6f959a9872e5bddf44cc9e0adce1e1a"},
-    {file = "triton-3.0.0-1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ce8520437c602fb633f1324cc3871c47bee3b67acf9756c1a66309b60e3216c"},
-    {file = "triton-3.0.0-1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e509deb77f1c067d8640725ef00c5cbfcb2052a1a3cb6a6d343841f92624eb"},
-    {file = "triton-3.0.0-1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bcbf3b1c48af6a28011a5c40a5b3b9b5330530c3827716b5fbf6d7adcc1e53e9"},
-    {file = "triton-3.0.0-1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6e5727202f7078c56f91ff13ad0c1abab14a0e7f2c87e91b12b6f64f3e8ae609"},
-]
-
-[package.dependencies]
-filelock = "*"
-
-[package.extras]
-build = ["cmake (>=3.20)", "lit"]
-tests = ["autopep8", "flake8", "isort", "llnl-hatchet", "numpy", "pytest", "scipy (>=1.7.1)"]
-tutorials = ["matplotlib", "pandas", "tabulate"]
 
 [[package]]
 name = "ttach"
@@ -7316,4 +7119,4 @@ onnx = ["onnx", "onnxconverter-common", "onnxruntime_gpu", "onnxsim"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.11"
-content-hash = "9daace415fb266e382e991fcf78a0256ba1a570a796e5b69f1209cd7abf50120"
+content-hash = "ab39f792521b9695a1dbfee0c0921440492f366c3ebfd959de6bb5950358fe2a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quadra"
-version = "2.4.0a0"
+version = "2.4.0"
 description = "Deep Learning experiment orchestration library"
 authors = [
 	"Federico Belotti <federico.belotti@orobix.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ quadra = "quadra.main:main"
 [tool.poetry.dependencies]
 python = ">=3.10,<3.11"
 
-torch = { version = "2.4.1", source = "torch_cu121" }
-torchvision = { version = "~0.19", source = "torch_cu121" }
+torch = { version = "2.6.0", source = "torch_cu126" }
+torchvision = { version = "~0.21", source = "torch_cu126" }
 
 pytorch_lightning = "~2.4"
 numpy = "<2"
@@ -85,8 +85,8 @@ onnxruntime_gpu = { version = "1.20.0", optional = true }
 onnxconverter-common = { version = "^1.14.0", optional = true }
 
 [[tool.poetry.source]]
-name = "torch_cu121"
-url = "https://download.pytorch.org/whl/cu121"
+name = "torch_cu126"
+url = "https://download.pytorch.org/whl/cu126"
 priority = "explicit"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quadra"
-version = "2.3.3"
+version = "2.4.0a0"
 description = "Deep Learning experiment orchestration library"
 authors = [
 	"Federico Belotti <federico.belotti@orobix.com>",

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.0a0"
+__version__ = "2.4.0"
 
 
 def get_version():

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.3"
+__version__ = "2.4.0a0"
 
 
 def get_version():

--- a/quadra/utils/export.py
+++ b/quadra/utils/export.py
@@ -163,14 +163,14 @@ def export_torchscript_model(
                 model_input_tensors.append(new_inp)
                 model_input_shapes.append(new_inp[0].shape)
 
-            model_inputs = (model_input_tensors, model_input_shapes)
+            model_inputs = (model_input_tensors, [model_input_shapes])
         else:
             new_inp = example_inputs.to(
                 device="cuda:0" if half_precision else "cpu",
                 dtype=torch.float16 if half_precision else torch.float32,
             )
             new_inp = new_inp.unsqueeze(0).repeat(batch_size, *(1 for x in new_inp.shape))
-            model_inputs = (new_inp, new_inp.shape)  # type: ignore[assignment]
+            model_inputs = (new_inp, [new_inp[0].shape])
     else:
         model_inputs = extract_torch_model_inputs(model, input_shapes, half_precision)
 
@@ -260,14 +260,14 @@ def export_onnx_model(
                 model_input_tensors.append(new_inp)
                 model_input_shapes.append(new_inp[0].shape)
 
-            model_inputs = (model_input_tensors, model_input_shapes)
+            model_inputs = (model_input_tensors, [model_input_shapes])
         else:
             new_inp = example_inputs.to(
                 device="cuda:0" if half_precision else "cpu",
                 dtype=torch.float16 if half_precision else torch.float32,
             )
             new_inp = new_inp.unsqueeze(0).repeat(batch_size, *(1 for x in new_inp.shape))
-            model_inputs = ([new_inp], new_inp.shape)  # type: ignore[assignment]
+            model_inputs = ([new_inp], [new_inp[0].shape])
     else:
         model_inputs = extract_torch_model_inputs(model, input_shapes, half_precision)
 

--- a/quadra/utils/export.py
+++ b/quadra/utils/export.py
@@ -119,6 +119,7 @@ def export_torchscript_model(
     input_shapes: list[Any] | None = None,
     half_precision: bool = False,
     model_name: str = "model.pt",
+    example_inputs: list[torch.Tensor] | tuple[torch.Tensor, ...] | torch.Tensor | None = None,
 ) -> tuple[str, Any] | None:
     """Export a PyTorch model with TorchScript.
 
@@ -128,6 +129,8 @@ def export_torchscript_model(
         output_path: Path to save the model
         half_precision: If True, the model will be exported with half precision
         model_name: Name of the exported model
+        example_inputs: If provided use this to evaluate the model instead of generating random inputs, it's expected to
+            be a list of tensors or a single tensor without batch dimension
 
     Returns:
         If the model is exported successfully, the path to the model and the input shape are returned.
@@ -144,7 +147,32 @@ def export_torchscript_model(
     else:
         model.cpu()
 
-    model_inputs = extract_torch_model_inputs(model, input_shapes, half_precision)
+    batch_size = 1
+    model_inputs: tuple[list[Any] | tuple[Any, ...] | torch.Tensor, list[Any]] | None
+    if example_inputs is not None:
+        if isinstance(example_inputs, Sequence):
+            model_input_tensors = []
+            model_input_shapes = []
+
+            for example_input in example_inputs:
+                new_inp = example_input.to(
+                    device="cuda:0" if half_precision else "cpu",
+                    dtype=torch.float16 if half_precision else torch.float32,
+                )
+                new_inp = new_inp.unsqueeze(0).repeat(batch_size, *(1 for x in new_inp.shape))
+                model_input_tensors.append(new_inp)
+                model_input_shapes.append(new_inp[0].shape)
+
+            model_inputs = (model_input_tensors, model_input_shapes)
+        else:
+            new_inp = example_inputs.to(
+                device="cuda:0" if half_precision else "cpu",
+                dtype=torch.float16 if half_precision else torch.float32,
+            )
+            new_inp = new_inp.unsqueeze(0).repeat(batch_size, *(1 for x in new_inp.shape))
+            model_inputs = (new_inp, new_inp.shape)  # type: ignore[assignment]
+    else:
+        model_inputs = extract_torch_model_inputs(model, input_shapes, half_precision)
 
     if model_inputs is None:
         return None
@@ -182,6 +210,9 @@ def export_onnx_model(
     input_shapes: list[Any] | None = None,
     half_precision: bool = False,
     model_name: str = "model.onnx",
+    example_inputs: list[torch.Tensor] | tuple[torch.Tensor, ...] | torch.Tensor | None = None,
+    rtol: float = 0.01,
+    atol: float = 5e-3,
 ) -> tuple[str, Any] | None:
     """Export a PyTorch model with ONNX.
 
@@ -192,6 +223,10 @@ def export_onnx_model(
         onnx_config: ONNX export configuration
         half_precision: If True, the model will be exported with half precision
         model_name: Name of the exported model
+        example_inputs: If provided use this to evaluate the model instead of generating random inputs, it's expected to
+            be a list of tensors or a single tensor without batch dimension
+        rtol: Relative tolerance for the ONNX safe export in fp16
+        atol: Absolute tolerance for the ONNX safe export in fp16
     """
     if not ONNX_AVAILABLE:
         log.warning("ONNX is not installed, can not export model in this format.")
@@ -210,9 +245,32 @@ def export_onnx_model(
     else:
         batch_size = 1
 
-    model_inputs = extract_torch_model_inputs(
-        model=model, input_shapes=input_shapes, half_precision=half_precision, batch_size=batch_size
-    )
+    model_inputs: tuple[list[Any] | tuple[Any, ...] | torch.Tensor, list[Any]] | None
+    if example_inputs is not None:
+        if isinstance(example_inputs, Sequence):
+            model_input_tensors = []
+            model_input_shapes = []
+
+            for example_input in example_inputs:
+                new_inp = example_input.to(
+                    device="cuda:0" if half_precision else "cpu",
+                    dtype=torch.float16 if half_precision else torch.float32,
+                )
+                new_inp = new_inp.unsqueeze(0).repeat(batch_size, *(1 for x in new_inp.shape))
+                model_input_tensors.append(new_inp)
+                model_input_shapes.append(new_inp[0].shape)
+
+            model_inputs = (model_input_tensors, model_input_shapes)
+        else:
+            new_inp = example_inputs.to(
+                device="cuda:0" if half_precision else "cpu",
+                dtype=torch.float16 if half_precision else torch.float32,
+            )
+            new_inp = new_inp.unsqueeze(0).repeat(batch_size, *(1 for x in new_inp.shape))
+            model_inputs = ([new_inp], new_inp.shape)  # type: ignore[assignment]
+    else:
+        model_inputs = extract_torch_model_inputs(model, input_shapes, half_precision)
+
     if model_inputs is None:
         return None
 
@@ -266,6 +324,8 @@ def export_onnx_model(
 
     if isinstance(inp, list):
         inp = tuple(inp)  # onnx doesn't like lists representing tuples of inputs
+    elif isinstance(inp, torch.Tensor):
+        inp = (inp,)
 
     if isinstance(inp, dict):
         raise ValueError("ONNX export does not support model with dict inputs")
@@ -290,6 +350,8 @@ def export_onnx_model(
             onnx_config=onnx_config,
             input_shapes=input_shapes,
             input_names=input_names,
+            rtol=rtol,
+            atol=atol,
         )
 
         if not is_export_ok:
@@ -324,6 +386,8 @@ def _safe_export_half_precision_onnx(
     onnx_config: DictConfig,
     input_shapes: list[Any],
     input_names: list[str],
+    rtol: float = 0.01,
+    atol: float = 5e-3,
 ) -> bool:
     """Check that the exported half precision ONNX model does not contain NaN values. If it does, attempt to export
     the model with a more stable export and overwrite the original model.
@@ -335,6 +399,8 @@ def _safe_export_half_precision_onnx(
         onnx_config: ONNX export configuration
         input_shapes: Input shapes for the model
         input_names: Input names for the model
+        rtol: Relative tolerance to evaluate the model
+        atol: Absolute tolerance to evaluate the model
 
     Returns:
         True if the model is stable or it was possible to export a more stable model, False otherwise.
@@ -381,7 +447,7 @@ def _safe_export_half_precision_onnx(
             with open(os.devnull, "w") as f, contextlib.redirect_stdout(f):
                 # This function prints a lot of information that is not useful for the user
                 model_fp16 = auto_convert_mixed_precision(
-                    model_fp32, test_data, rtol=0.01, atol=5e-3, keep_io_types=False
+                    model_fp32, test_data, rtol=rtol, atol=atol, keep_io_types=False
                 )
             onnx.save(model_fp16, export_model_path)
 
@@ -431,6 +497,9 @@ def export_model(
     input_shapes: list[Any] | None = None,
     idx_to_class: dict[int, str] | None = None,
     pytorch_model_type: Literal["backbone", "model"] = "model",
+    example_inputs: list[Any] | tuple[Any, ...] | torch.Tensor | None = None,
+    rtol: float = 0.01,
+    atol: float = 5e-3,
 ) -> tuple[dict[str, Any], dict[str, str]]:
     """Generate deployment models for the task.
 
@@ -443,6 +512,9 @@ def export_model(
         idx_to_class: Mapping from class index to class name
         pytorch_model_type: Type of the pytorch model config to be exported, if it's backbone on disk we will save the
             config.backbone config, otherwise we will save the config.model
+        example_inputs: If provided use this to evaluate the model instead of generating random inputs
+        rtol: Relative tolerance for the ONNX safe export in fp16
+        atol: Absolute tolerance for the ONNX safe export in fp16
 
     Returns:
         If the model is exported successfully, return a dictionary containing information about the exported model and
@@ -468,6 +540,7 @@ def export_model(
                 input_shapes=input_shapes,
                 output_path=export_folder,
                 half_precision=half_precision,
+                example_inputs=example_inputs,
             )
 
             if out is None:
@@ -495,6 +568,9 @@ def export_model(
                 onnx_config=config.export.onnx,
                 input_shapes=input_shapes,
                 half_precision=half_precision,
+                example_inputs=example_inputs,
+                rtol=rtol,
+                atol=atol,
             )
 
             if out is None:

--- a/tests/tasks/test_ssl.py
+++ b/tests/tasks/test_ssl.py
@@ -61,6 +61,7 @@ def test_dino(tmp_path: Path, base_classification_dataset: base_classification_d
         "loss.warmup_teacher_temp_epochs=1",
         "trainer.max_epochs=2",
         "datamodule.num_workers=1",
+        "datamodule.batch_size=1",
     ]
     overrides += setup_trainer_for_lightning()
 

--- a/tests/tasks/test_ssl.py
+++ b/tests/tasks/test_ssl.py
@@ -60,6 +60,7 @@ def test_dino(tmp_path: Path, base_classification_dataset: base_classification_d
         "backbone=resnet18",
         "loss.warmup_teacher_temp_epochs=1",
         "trainer.max_epochs=2",
+        "datamodule.num_workers=1",
     ]
     overrides += setup_trainer_for_lightning()
 


### PR DESCRIPTION
## Summary

Upgrade torch from 2.4.1 to 2.6.0

#### Added

- Add a way to use validation data to evaluate ONNX fp16 mixed precision export

#### Updated

- Update torch to 2.6.0+cu126 and torchvision to 0.21.0+cu126
- Increase minimum rtol and atol for finetuning model export to avoid errors on efficientnet_b0 export


## Type of Change

Please select the one relevant option below:
- Breaking change

## Checklist

Please confirm that the following tasks have been completed:

- [X] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [X] I have added unit tests for my changes, or updated existing tests if necessary.
- [X] I have updated the documentation, if applicable.
- [X] I have installed pre-commit and run locally for my code changes.

![immagine](https://github.com/user-attachments/assets/6e4078d1-1210-4f0b-af18-7a70425aee03)
