### PR TITLE
Fix/anomaly scores normalization consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,14 @@ Starting from version 2.6.1, releases are automatically created when changes are
 
 ### [2.8.1]
 
+#### Updated
+
+- Anomalib-orobix to v0.7.0.dev151 in order to make optimal threshold selection more robust with respect to floating point operations.
+
 #### Fixed
 
 - `normalize_anomaly_score` now accepts an optional `eval_threshold` (`EvalThreshold`) parameter. When provided, consistency enforcement uses the actual evaluation boundary instead of always using the training threshold at 100.0, preventing misclassification of samples whose raw score falls close to the evaluation thresholds.
-- Consistency enforcement in anomaly score normalization now uses `np.nextafter`/`torch.nextafter` (dtype-aware) instead of hardcoded epsilon values (e.g. `99.99`), eliminating ULP-gap misclassifications especially at low-precision (fp16) boundaries.
+- Consistency enforcement in anomaly score normalization now uses `np.nextafter`/`torch.nextafter` (dtype-aware) instead of hardcoded epsilon values, eliminating ULP-gap misclassifications especially at low-precision (fp16) boundaries.
 - `AnomalibEvaluation` now builds an `EvalThreshold` from the optimal evaluation threshold and passes it to `normalize_anomaly_score`, ensuring consistent predictions between raw and normalized anomaly scores and anomaly maps.
 
 ### [2.8.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Starting from version 2.6.1, releases are automatically created when changes are
 
 **Note**: If a tag for the current version already exists, the workflow will skip tag and release creation to avoid duplicates.
 
+### [2.8.1]
+
+#### Fixed
+
+- `normalize_anomaly_score` now accepts an optional `eval_threshold` (`EvalThreshold`) parameter. When provided, consistency enforcement uses the actual evaluation boundary instead of always using the training threshold at 100.0, preventing misclassification of samples whose raw score falls close to the evaluation thresholds.
+- Consistency enforcement in anomaly score normalization now uses `np.nextafter`/`torch.nextafter` (dtype-aware) instead of hardcoded epsilon values (e.g. `99.99`), eliminating ULP-gap misclassifications especially at low-precision (fp16) boundaries.
+- `AnomalibEvaluation` now builds an `EvalThreshold` from the optimal evaluation threshold and passes it to `normalize_anomaly_score`, ensuring consistent predictions between raw and normalized anomaly scores and anomaly maps.
+
 ### [2.8.0]
 
 #### Added

--- a/poetry.lock
+++ b/poetry.lock
@@ -209,14 +209,14 @@ files = [
 
 [[package]]
 name = "anomalib-orobix"
-version = "0.7.0.dev150"
+version = "0.7.0.dev151"
 description = "Orobix anomalib fork"
 optional = false
 python-versions = "<3.11,>=3.10"
 groups = ["main"]
 files = [
-    {file = "anomalib_orobix-0.7.0.dev150-py3-none-any.whl", hash = "sha256:bbf018c6cede939e8b48aea66c5d93a7eb0f21ac19de0d086fdcc9e55b35eda2"},
-    {file = "anomalib_orobix-0.7.0.dev150.tar.gz", hash = "sha256:835f9930c5807d469083bf363f17dfb784d65bdc40feeca6029f034007e010ea"},
+    {file = "anomalib_orobix-0.7.0.dev151-py3-none-any.whl", hash = "sha256:3b5cd037a153f5fbf7bcf8368724d15746a6e02f09b41b4682467338d51ae05c"},
+    {file = "anomalib_orobix-0.7.0.dev151.tar.gz", hash = "sha256:d40d720dbccffbd9cef0b6d68c794fa4a8003a21684c2a78d0f0590d663b24de"},
 ]
 
 [package.dependencies]
@@ -7484,4 +7484,4 @@ onnx = ["onnx", "onnxconverter-common", "onnxruntime_gpu", "onnxsim"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.11"
-content-hash = "c03f5c770d5bbb907356601d1d14154c9260acfbe24a0996acf4c018c79c8467"
+content-hash = "4e23f2a0f94c1b789b568b9256186a1ccb1eadfcdd2afa4d61c4a2ea6877da9a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quadra"
-version = "2.8.0"
+version = "2.8.1"
 description = "Deep Learning experiment orchestration library"
 authors = [
 	"Federico Belotti <federico.belotti@orobix.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ h5py = "~3.8"
 timm = "1.0.24"
 segmentation_models_pytorch = "0.5.0"
 
-anomalib-orobix = "0.7.0.dev150"
+anomalib-orobix = "0.7.0.dev151"
 xxhash = "~3.2"
 torchinfo = "~1.8"
 typing_extensions = { version = "4.11.0", python = "<3.10" }

--- a/quadra/__init__.py
+++ b/quadra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.8.0"
+__version__ = "2.8.1"
 
 
 def get_version():

--- a/quadra/utils/anomaly.py
+++ b/quadra/utils/anomaly.py
@@ -76,6 +76,8 @@ def ensure_scores_consistency(
         # Work in scores dtype, cast boundaries to the same dype to ensure that casts take effect
         _inf = torch.tensor(float("inf"), dtype=normalized_score.dtype, device=device)
         anomaly_boundary = torch.tensor(boundary, dtype=normalized_score.dtype, device=device)
+        # If dtype cast causes anomaly_boundary to be smaller than normalized boundary (float),
+        # increase it up to the next representable value
         if float(anomaly_boundary) < boundary:
             anomaly_boundary = torch.nextafter(anomaly_boundary, _inf)
         below_boundary = torch.nextafter(torch.tensor(boundary, dtype=normalized_score.dtype, device=device), -_inf)
@@ -93,6 +95,8 @@ def ensure_scores_consistency(
         # Work in scores dtype, cast boundaries to the same dype to ensure that casts take effect
         dtype = normalized_score.dtype if isinstance(normalized_score, np.ndarray) else np.float64
         anomaly_boundary = np.array(boundary, dtype=dtype)
+        # If dtype cast causes anomaly_boundary to be smaller than normalized boundary (float),
+        # increase it up to the next representable value
         if float(anomaly_boundary) < boundary:
             anomaly_boundary = np.nextafter(anomaly_boundary, np.array(np.inf, dtype=dtype))
         below_boundary = np.nextafter(np.array(boundary, dtype=dtype), np.array(-np.inf, dtype=dtype))

--- a/tests/utilities/test_anomaly_utils.py
+++ b/tests/utilities/test_anomaly_utils.py
@@ -1,7 +1,174 @@
-import pytest
-from quadra.utils.anomaly import normalize_anomaly_score
-import torch
 import numpy as np
+import pytest
+import torch
+
+from quadra.utils.anomaly import EvalThreshold, ensure_scores_consistency, normalize_anomaly_score
+
+
+class TestEvalThreshold:
+    def test_valid(self):
+        et = EvalThreshold(raw=10.0, normalized=100.0)
+        assert et.raw == 10.0
+        assert et.normalized == 100.0
+
+    @pytest.mark.parametrize("raw", [0.0, -1.0])
+    def test_invalid_raw(self, raw: float):
+        with pytest.raises(ValueError, match="raw threshold"):
+            EvalThreshold(raw=raw, normalized=100.0)
+
+    @pytest.mark.parametrize("normalized", [0.0, -1.0])
+    def test_invalid_normalized(self, normalized: float):
+        with pytest.raises(ValueError, match="normalized threshold"):
+            EvalThreshold(raw=10.0, normalized=normalized)
+
+
+class TestEnsureScoresConsistency:
+    """The invariant: (result >= eval_threshold.normalized) == (raw_score >= eval_threshold.raw).
+
+    All inputs are deliberately inconsistent (normalized on the *wrong* side
+    of the boundary) so that the function is forced to correct them.
+    """
+
+    @pytest.mark.parametrize(
+        "raw_score, wrong_normalized, eval_raw, eval_norm, expected_pred",
+        [
+            # IS anomaly, normalized placed one step BELOW boundary
+            (9.0, float(np.nextafter(np.float32(80.0), np.float32(-np.inf))), 8.0, 80.0, 1),
+            # IS anomaly, raw score exactly AT eval_raw (>= is inclusive)
+            (8.0, 79.9, 8.0, 80.0, 1),
+            # NOT anomaly, normalized placed exactly AT boundary (not strictly below)
+            (7.0, 80.0, 8.0, 80.0, 0),
+            # NOT anomaly, normalized placed well above boundary
+            (7.0, 95.0, 8.0, 80.0, 0),
+        ],
+    )
+    def test_scalar_np_fp32(self, raw_score, wrong_normalized, eval_raw, eval_norm, expected_pred):
+        et = EvalThreshold(raw=eval_raw, normalized=eval_norm)
+        result = ensure_scores_consistency(
+            np.array(wrong_normalized, dtype=np.float32),
+            np.array(raw_score, dtype=np.float32),
+            et,
+        )
+        assert int(result >= eval_norm) == expected_pred
+
+    @pytest.mark.parametrize(
+        "raw_score, wrong_normalized, eval_raw, eval_norm, expected_pred",
+        [
+            (9.0, 79.0, 8.0, 80.0, 1),
+            (7.0, 85.0, 8.0, 80.0, 0),
+        ],
+    )
+    def test_scalar_np_fp16(self, raw_score, wrong_normalized, eval_raw, eval_norm, expected_pred):
+        et = EvalThreshold(raw=eval_raw, normalized=eval_norm)
+        result = ensure_scores_consistency(
+            np.array(wrong_normalized, dtype=np.float16),
+            np.array(raw_score, dtype=np.float16),
+            et,
+        )
+        assert int(result >= eval_norm) == expected_pred
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float16])
+    def test_array_np_wrong_side(self, dtype):
+        """Every score is on the wrong side of the boundary so the function
+        must correct all of them."""
+        eval_raw, eval_norm = 8.0, 80.0
+        et = EvalThreshold(raw=eval_raw, normalized=eval_norm)
+
+        raw_scores = np.array([4.0, 7.0, 8.0, 9.0, 12.0], dtype=dtype)
+        # anomaly scores (8,9,12) placed BELOW boundary; non-anomaly (4,7) placed ABOVE
+        wrong_normalized = np.array([85.0, 85.0, 75.0, 75.0, 75.0], dtype=dtype)
+
+        result = ensure_scores_consistency(wrong_normalized.copy(), raw_scores, et)
+
+        raw_preds = (raw_scores >= eval_raw).astype(int)
+        norm_preds = (result >= eval_norm).astype(int)
+        np.testing.assert_array_equal(norm_preds, raw_preds)
+
+    @pytest.mark.parametrize(
+        "raw_score, wrong_normalized, eval_raw, eval_norm, expected_pred",
+        [
+            (9.0, float(np.nextafter(np.float32(80.0), np.float32(-np.inf))), 8.0, 80.0, 1),
+            (8.0, 79.9, 8.0, 80.0, 1),
+            (7.0, 80.0, 8.0, 80.0, 0),
+            (7.0, 95.0, 8.0, 80.0, 0),
+        ],
+    )
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_scalar_torch(self, raw_score, wrong_normalized, eval_raw, eval_norm, expected_pred, dtype):
+        et = EvalThreshold(raw=eval_raw, normalized=eval_norm)
+        result = ensure_scores_consistency(
+            torch.tensor(wrong_normalized, dtype=dtype),
+            torch.tensor(raw_score, dtype=dtype),
+            et,
+        )
+        assert int(result >= eval_norm) == expected_pred
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_array_torch_wrong_side(self, dtype):
+        eval_raw, eval_norm = 8.0, 80.0
+        et = EvalThreshold(raw=eval_raw, normalized=eval_norm)
+
+        raw_scores = torch.tensor([4.0, 7.0, 8.0, 9.0, 12.0], dtype=dtype)
+        wrong_normalized = torch.tensor([85.0, 85.0, 75.0, 75.0, 75.0], dtype=dtype)
+
+        result = ensure_scores_consistency(wrong_normalized.clone(), raw_scores, et)
+
+        raw_preds = (raw_scores >= eval_raw).int()
+        norm_preds = (result >= eval_norm).int()
+        assert torch.equal(norm_preds, raw_preds)
+
+    @pytest.mark.parametrize(
+        "boundary",
+        [
+            80.0,  # exactly representable in fp16
+            80.03,  # rounds DOWN in fp16 (fp16(80.03) = 80.0 < 80.03) → ceiling needed
+            99.995,  # rounds DOWN in fp16 → ceiling needed
+        ],
+    )
+    def test_fp16_np_anomaly_clipped_to_ceiling(self, boundary):
+        """IS anomaly score placed at fp16(boundary)-10 must be clipped to a value
+        that is still >= boundary (float64) after the ceiling rounding."""
+        et = EvalThreshold(raw=2.0, normalized=boundary)
+        raw = np.array(2.0, dtype=np.float16)
+        # Place normalized score well below boundary so clipping must fire
+        wrong_norm = np.array(float(np.float16(boundary)) - 10.0, dtype=np.float16)
+        result = ensure_scores_consistency(wrong_norm, raw, et)
+        assert result >= boundary
+
+    @pytest.mark.parametrize(
+        "boundary",
+        [80.0, 80.03, 99.995],
+    )
+    def test_fp16_np_non_anomaly_clipped_below_boundary(self, boundary):
+        """NOT anomaly score placed well above boundary must be clipped to a value
+        that is strictly < boundary (float64)."""
+        et = EvalThreshold(raw=2.0, normalized=boundary)
+        raw = np.array(0.5, dtype=np.float16)
+        wrong_norm = np.array(float(np.float16(boundary)) + 10.0, dtype=np.float16)
+        result = ensure_scores_consistency(wrong_norm, raw, et)
+        assert result < boundary
+
+    @pytest.mark.parametrize(
+        "boundary",
+        [80.0, 80.03, 99.995],
+    )
+    def test_fp16_torch_anomaly_clipped_to_ceiling(self, boundary):
+        et = EvalThreshold(raw=2.0, normalized=boundary)
+        raw = torch.tensor(2.0, dtype=torch.float16)
+        wrong_norm = torch.tensor(float(torch.tensor(boundary, dtype=torch.float16)) - 10.0, dtype=torch.float16)
+        result = ensure_scores_consistency(wrong_norm, raw, et)
+        assert result >= boundary
+
+    @pytest.mark.parametrize(
+        "boundary",
+        [80.0, 80.03, 99.995],
+    )
+    def test_fp16_torch_non_anomaly_clipped_below_boundary(self, boundary):
+        et = EvalThreshold(raw=2.0, normalized=boundary)
+        raw = torch.tensor(0.5, dtype=torch.float16)
+        wrong_norm = torch.tensor(float(torch.tensor(boundary, dtype=torch.float16)) + 10.0, dtype=torch.float16)
+        result = ensure_scores_consistency(wrong_norm, raw, et)
+        assert result < boundary
 
 
 @pytest.mark.parametrize("raw_score, threshold", [(1.345, 1.24), (1.24, 1.345)])
@@ -64,3 +231,81 @@ def test_anomaly_score_normalization_np_fp16_with_dim(raw_score: float, threshol
 def test_anomaly_score_normalization_float(raw_score: float, threshold: float):
     normalized_score = normalize_anomaly_score(raw_score, threshold)
     np.testing.assert_allclose(normalized_score, raw_score / threshold * 100.0)
+
+
+class TestNormalizeAnomalyScoreWithEvalThreshold:
+    """Verify (normalized >= eval_norm) == (raw >= eval_raw) for every sample."""
+
+    @pytest.mark.parametrize(
+        "scores, training, eval_raw, eval_norm",
+        [
+            # eval < training: scores between eval and training boundaries are IS anomaly
+            # in raw space but cross the training boundary → would be misclassified without
+            # eval_threshold enforcing consistency at the right boundary
+            ([4.0, 7.0, 8.0, 9.5, 12.0], 10.0, 8.0, 80.0),
+            # eval > training: scores between training and eval boundaries cross the training
+            # boundary but are still NOT anomaly relative to the eval threshold
+            ([8.0, 9.0, 10.0, 11.0, 13.0], 10.0, 12.0, 120.0),
+            # eval == training: default path, kept for non-regression
+            ([8.0, 9.0, 10.0, 11.0, 12.0], 10.0, 10.0, 100.0),
+        ],
+    )
+    @pytest.mark.parametrize("dtype", [np.float32, np.float16])
+    def test_consistency_np(self, scores, training, eval_raw, eval_norm, dtype):
+        et = EvalThreshold(raw=eval_raw, normalized=eval_norm)
+        raw = np.array(scores, dtype=dtype)
+        result = normalize_anomaly_score(raw.copy(), training, eval_threshold=et)
+
+        raw_preds = (raw >= eval_raw).astype(int)
+        norm_preds = (result >= eval_norm).astype(int)
+        np.testing.assert_array_equal(norm_preds, raw_preds)
+
+    @pytest.mark.parametrize(
+        "scores, training, eval_raw, eval_norm",
+        [
+            ([4.0, 7.0, 8.0, 9.5, 12.0], 10.0, 8.0, 80.0),
+            ([8.0, 9.0, 10.0, 11.0, 13.0], 10.0, 12.0, 120.0),
+            ([8.0, 9.0, 10.0, 11.0, 12.0], 10.0, 10.0, 100.0),
+        ],
+    )
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    def test_consistency_torch(self, scores, training, eval_raw, eval_norm, dtype):
+        et = EvalThreshold(raw=eval_raw, normalized=eval_norm)
+        raw = torch.tensor(scores, dtype=dtype)
+        result = normalize_anomaly_score(raw.clone(), training, eval_threshold=et)
+
+        raw_preds = (raw >= eval_raw).long()
+        norm_preds = (result >= eval_norm).long()
+        assert torch.equal(norm_preds, raw_preds), (
+            f"dtype={dtype}: raw_preds={raw_preds.tolist()}, norm_preds={norm_preds.tolist()}"
+        )
+
+    def test_regression_fp32_score_at_training_boundary(self):
+        """Regression for the ULP-gap bug.
+
+        For a fp32 score at nextafter(training_threshold, -inf), fp32 arithmetic
+        normalises it to a value below the float64 eval_norm.  Without eval_threshold
+        the prediction is therefore False (NOT anomaly) even though the raw score
+        IS anomaly relative to eval_raw.
+
+        The assertion on `result_default` verifies the input actually creates an
+        inconsistency; if it does not, the test should be revised.
+        """
+        training = 10.0
+        # Largest fp32 value strictly below training threshold
+        eval_raw = float(np.nextafter(np.float32(training), np.float32(-np.inf)))
+        # eval_norm in float64 lands in the ULP gap above nextafter(fp32(100), -inf)
+        eval_norm = eval_raw / training * 100.0
+
+        score = np.array([eval_raw], dtype=np.float32)
+
+        result_default = normalize_anomaly_score(score.copy(), training)
+        # Precondition: without eval_threshold the prediction IS wrong
+        assert result_default[0] < eval_norm, (
+            "Test precondition failed: expected the default path to produce an inconsistent "
+            f"result ({result_default[0]:.10f} should be < eval_norm={eval_norm:.10f})"
+        )
+
+        et = EvalThreshold(raw=eval_raw, normalized=eval_norm)
+        result_fix = normalize_anomaly_score(score.copy(), training, eval_threshold=et)
+        assert result_fix[0] >= eval_norm, f"Fix failed: {result_fix[0]:.10f} < eval_norm={eval_norm:.10f}"


### PR DESCRIPTION
## Summary

Describe the purpose of the pull request, including:

**Updated**
- Anomalib-orobix to v0.7.0.dev151 in order to make optimal threshold selection more robust with respect to floating point operations.

**Fixed**
- `normalize_anomaly_score` now accepts an optional `eval_threshold` (`EvalThreshold`) parameter. When provided, consistency enforcement uses the actual evaluation boundary instead of always using the training threshold at 100.0, preventing misclassification of samples whose raw score falls close to the evaluation thresholds.
- Consistency enforcement in anomaly score normalization now uses `np.nextafter`/`torch.nextafter` (dtype-aware) instead of hardcoded epsilon values, eliminating ULP-gap misclassifications especially at low-precision (fp16) boundaries.
- `AnomalibEvaluation` now builds an `EvalThreshold` from the optimal evaluation threshold and passes it to `normalize_anomaly_score`, ensuring consistent predictions between raw and normalized anomaly scores and anomaly maps.

## Type of Change

Please select the one relevant option below:

- Bug fix (non-breaking change that solves an issue)

## Checklist

Please confirm that the following tasks have been completed:

- [x] I have tested my changes locally and they work as expected. (Please describe the tests you performed.)
- [x] I have added unit tests for my changes, or updated existing tests if necessary.
- [x] I have updated the documentation, if applicable.
- [x] I have installed pre-commit and run locally for my code changes.